### PR TITLE
Add Ceph rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Contains "smoke-alarm" rules for these use cases:
 - landscape server
 - charmed kubeflow
 - charmed opensearch
+- charmed ceph
 
 This repository should be referenced by the [cos-configuration-k8s](https://charmhub.io/cos-configuration-k8s) charm to forward alert rules to Canonical Observability Stack (COS).
 
@@ -18,5 +19,6 @@ See audit logging and other setup guides for each use case:
 - [Landscape Server](docs/setup_guides/landscape_server_references.md)
 - [Charmed Kubeflow](docs/setup_guides/charmed_kubeflow_setup.md)
 - [Charmed OpenSearch](docs/setup_guides/charmed_opensearch_setup.md)
+- [Charmed Ceph](docs/setup_guides/ceph_api_reference.md)
 
 See all alert rules and example log references in [rules.md](docs/rules.md) and [references.md](docs/references.md).

--- a/docs/references.md
+++ b/docs/references.md
@@ -313,22 +313,22 @@ Alert will trigger if >3 security audit events (FAILED_LOGIN, MISSING_PRIVILEGES
 
 These log lines are from Ceph Manager logs indicating Ceph API failures (HTTP status codes 4xx or 5xx).
 
-### CephAPIFailureRateHigh
+### CephAPIFailureRate*
 **Example log line:**
 
 In `/var/log/ceph/ceph-mgr.*.log`:
 ```
 2026-01-09T02:18:38.259+0000 7f7b3c7e8640  0 [dashboard INFO request] [::ffff:10.149.54.71:53300] [GET] [404] [0.007s] [admin] [513.0B] /api/random
 ```
-Alert triggers if API failure rate exceeds 20% over 1 hour (excludes /api/auth endpoint).
+Alert triggers if API failure rate exceeds threshold over 1 hour (excludes /api/auth endpoint): >20% for Warning, >70% for Critical.
 
-### CephAuthFailureRateHigh
+### CephAuthFailureRate*
 **Example log line:**
 
 In `/var/log/ceph/ceph-mgr.*.log`:
 ```
 2026-01-09T01:06:40.013+0000 7f7b3f7ee640  0 [dashboard INFO request] [::ffff:10.149.54.71:55826] [POST] [400] [0.150s] [85.0B] [0f83d360-51db-4bad-aa44-0269b71aef10] /api/auth
 ```
-Alert triggers if authentication failure rate exceeds 20% over 1 hour.
+Alert triggers if authentication failure rate exceeds threshold over 1 hour: >20% for Warning, >70% for Critical.
 
 ---

--- a/docs/references.md
+++ b/docs/references.md
@@ -308,3 +308,27 @@ In `/var/snap/opensearch/common/var/log/opensearch/*_server.json` (collected via
 Alert will trigger if >3 security audit events (FAILED_LOGIN, MISSING_PRIVILEGES, BAD_HEADERS, SSL_EXCEPTION, opensearch_SECURITY_INDEX_ATTEMPT) occur in 10 minutes.
 
 ---
+
+## Charmed Ceph
+
+These log lines are from Ceph Manager logs indicating Ceph API failures (HTTP status codes 4xx or 5xx).
+
+### CephAPIFailureRateHigh
+**Example log line:**
+
+In `/var/log/ceph/ceph-mgr.*.log`:
+```
+2026-01-09T02:18:38.259+0000 7f7b3c7e8640  0 [dashboard INFO request] [::ffff:10.149.54.71:53300] [GET] [404] [0.007s] [admin] [513.0B] /api/random
+```
+Alert triggers if API failure rate exceeds 20% over 1 hour (excludes /api/auth endpoint).
+
+### CephAuthFailureRateHigh
+**Example log line:**
+
+In `/var/log/ceph/ceph-mgr.*.log`:
+```
+2026-01-09T01:06:40.013+0000 7f7b3f7ee640  0 [dashboard INFO request] [::ffff:10.149.54.71:55826] [POST] [400] [0.150s] [85.0B] [0f83d360-51db-4bad-aa44-0269b71aef10] /api/auth
+```
+Alert triggers if authentication failure rate exceeds 20% over 1 hour.
+
+---

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -128,6 +128,16 @@ An overview of all alert rules.
 
 ## Charmed Ceph Alert Rules
 
+### Prometheus Alerts
+> **Note:** One alert will be triggered per OSD affected.
+
+| Alert Name | Trigger Condition | Severity |
+|------------|-------------------|----------|
+| **CephOSDDownSpecific** | An OSD down for 10 minutes | Warning |
+| **CephOSDCommitLatencyHigh** | OSD commit latency >50ms for 10 minutes | Warning |
+| **CephOSDCommitLatencyCritical** | OSD commit latency >200ms for 10 minutes | Critical |
+| **CephOSDCommitLatencyOutlier** | OSD commit latency >50ms AND >2x cluster average for 10 minutes | Warning |
+
 ### Loki Alerts
 | Alert Name | Trigger Condition | Severity |
 |------------|-------------------|----------|

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -125,3 +125,11 @@ An overview of all alert rules.
 |------------|-------------------|----------|
 | **CharmedOpenSearchSecurityAuditEventsHigh** | >3 security audit events in 10 minutes | Warning |
 | **CharmedOpenSearchSecurityAuditEventsCritical** | >5 security audit events in 10 minutes | Critical |
+
+## Charmed Ceph Alert Rules
+
+### Loki Alerts
+| Alert Name | Trigger Condition | Severity |
+|------------|-------------------|----------|
+| **CephAPIFailureRateHigh** | Ceph API failure rate >20% over 1 hour (excludes /api/auth) | Warning |
+| **CephAuthFailureRateHigh** | Ceph authentication failure rate >20% over 1 hour | Warning |

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -133,9 +133,9 @@ An overview of all alert rules.
 |------------|-------------------|----------|
 | **CephOSDDownSpecific** | An OSD down for 10 minutes | Warning |
 | **CephOSDDownAllOnHost** | All OSDs in a host down for 10 minutes | Critical |
-| **CephOSDCommitLatencyHigh** | OSD commit latency >50ms for 10 minutes | Warning |
-| **CephOSDCommitLatencyCritical** | OSD commit latency >200ms for 10 minutes | Critical |
-| **CephOSDCommitLatencyOutlier** | OSD commit latency >50ms AND >2x cluster average for 10 minutes | Warning |
+| **CephOSDCommitLatencyHigh** | OSD commit latency >150ms for 10 minutes | Warning |
+| **CephOSDCommitLatencyCritical** | OSD commit latency >300ms for 10 minutes | Critical |
+| **CephOSDCommitLatencyOutlier** | OSD commit latency >150ms AND >2x cluster average for 10 minutes | Warning |
 
 ### Loki Alerts
 | Alert Name | Trigger Condition | Severity |

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -129,11 +129,10 @@ An overview of all alert rules.
 ## Charmed Ceph Alert Rules
 
 ### Prometheus Alerts
-> **Note:** One alert will be triggered per OSD affected.
-
 | Alert Name | Trigger Condition | Severity |
 |------------|-------------------|----------|
 | **CephOSDDownSpecific** | An OSD down for 10 minutes | Warning |
+| **CephOSDDownAllOnHost** | All OSDs in a host down for 10 minutes | Critical |
 | **CephOSDCommitLatencyHigh** | OSD commit latency >50ms for 10 minutes | Warning |
 | **CephOSDCommitLatencyCritical** | OSD commit latency >200ms for 10 minutes | Critical |
 | **CephOSDCommitLatencyOutlier** | OSD commit latency >50ms AND >2x cluster average for 10 minutes | Warning |

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -132,4 +132,6 @@ An overview of all alert rules.
 | Alert Name | Trigger Condition | Severity |
 |------------|-------------------|----------|
 | **CephAPIFailureRateHigh** | Ceph API failure rate >20% over 1 hour (excludes /api/auth) | Warning |
+| **CephAPIFailureRateCritical** | Ceph API failure rate >70% over 1 hour (excludes /api/auth) | Critical |
 | **CephAuthFailureRateHigh** | Ceph authentication failure rate >20% over 1 hour | Warning |
+| **CephAuthFailureRateCritical** | Ceph authentication failure rate >70% over 1 hour | Critical |

--- a/docs/setup_guides/ceph_api_reference.md
+++ b/docs/setup_guides/ceph_api_reference.md
@@ -1,9 +1,9 @@
 # Ceph RESTful API (Ceph API) Failure Rate Alerts
 
 ## Overview
-The Ceph Manager (MGR) exposes RESTful API (which is known as **Ceph API**) via its Ceph Dashboard module for managing and monitoring the Ceph cluster. Notice that this "Ceph API" is only for Ceph cluster management (check cluster health, view OSD status, create pools, manage users, etc.,) and does not handle data operations (RBD Operations, Object Storage Operations, File Storage Operations). Ceph RADOS Gateway (RGW) exposes its own RESTful API for data operations, while Ceph RBD and CephFS use the native Ceph protocol (RADOS) for data operations instead of RESTful APIs.
+The Ceph Manager (MGR) exposes RESTful API (which is known as **Ceph API**) via its Ceph Dashboard module for managing and monitoring the Ceph cluster. Notice that this "Ceph API" is only for Ceph cluster management (check cluster health, view OSD status, create pools, manage users, etc.) and does not handle data operations (RBD Operations, Object Storage Operations, File Storage Operations). Ceph RADOS Gateway (RGW) exposes its own RESTful API for data operations, while Ceph RBD and CephFS use the native Ceph protocol (RADOS) for data operations instead of RESTful APIs.
 
-The scope of the alert rules in [ceph_dashboard_rules.rule](../rules/prod/loki/ceph_dashboard_rules.rule) is to monitor the API access failure rates (via HTTP status codes) for a [charmed Ceph cluster](https://ubuntu.com/ceph/docs) using the Ceph API, which is only for control plane operations rather than data plane operations.
+The scope of the alert rules in [ceph_dashboard_rules.rule](../../rules/prod/loki/ceph_dashboard_rules.rule) is to monitor the API access failure rates (via HTTP status codes) for a [charmed Ceph cluster](https://ubuntu.com/ceph/docs) using the Ceph API, which is only for control plane operations rather than data plane operations.
 
 > **Note:** The Ceph dashboard module is optional. If you do not plan to use the Ceph dashboard for managing and monitoring the Ceph cluster, these alert rules will not be applicable.
 
@@ -54,10 +54,10 @@ juju deploy cos-configuration-k8s cos-config \
     --config git_depth=1 \
     --config loki_alert_rules_path=rules/prod/loki/ \
 
-# Relate to Loki and Prometheus
+# Relate to Loki
 juju relate loki cos-config
 ```
-After this point, the alert rules in [ceph_dashboard_rules.rule](../rules/prod/loki/ceph_dashboard_rules.rule) will be applicable.
+After this point, the alert rules in [ceph_dashboard_rules.rule](../../rules/prod/loki/ceph_dashboard_rules.rule) will be applicable.
 
 ## API Log Source and Format
 The HTTP access logs for Ceph API are recorded in `/var/log/ceph/ceph-mgr.*.log` file in the `ceph-mon` machine. Example log entries:

--- a/docs/setup_guides/ceph_api_reference.md
+++ b/docs/setup_guides/ceph_api_reference.md
@@ -1,0 +1,79 @@
+# Ceph RESTful API (Ceph API) Failure Rate Alerts
+
+## Overview
+The Ceph Manager (MGR) exposes RESTful API (which is known as **Ceph API**) via its Ceph Dashboard module for managing and monitoring the Ceph cluster. Notice that this "Ceph API" is only for Ceph cluster management (check cluster health, view OSD status, create pools, manage users, etc.,) and does not handle data operations (RBD Operations, Object Storage Operations, File Storage Operations). Ceph RADOS Gateway (RGW) exposes its own RESTful API for data operations, while Ceph RBD and CephFS use the native Ceph protocol (RADOS) for data operations instead of RESTful APIs.
+
+The scope of the alert rules in [ceph_dashboard_rules.rule](../rules/prod/loki/ceph_dashboard_rules.rule) is to monitor the API access failure rates (via HTTP status codes) for a [charmed Ceph cluster](https://ubuntu.com/ceph/docs) using the Ceph API, which is only for control plane operations rather than data plane operations.
+
+> **Note:** The Ceph dashboard module is optional. If you do not plan to use the Ceph dashboard for managing and monitoring the Ceph cluster, these alert rules will not be applicable.
+
+**Reference:**
+- [Ceph RESTful API Documentation](https://docs.ceph.com/en/latest/mgr/ceph_api/)
+- [Ceph Dashboard](https://docs.ceph.com/en/latest/mgr/dashboard/#ceph-dashboard)
+
+## Pre-requisites
+- [COS](https://documentation.ubuntu.com/observability/latest/) deployment
+- The charmed Ceph cluster should already be managed and monitored via the Ceph Dashboard module. This means the [ceph-dashboard charm](https://charmhub.io/ceph-dashboard) is already deployed and related to [ceph-mon charm](https://charmhub.io/ceph-mon). If not, and now the admin wants to manage the Ceph cluster using the Ceph Dashboard, this can be done following this [guide](https://ubuntu.com/ceph/docs/install-dashboard#deployment). To quickly verify the dashboard is enabled:
+    ```bash
+    $ juju exec -u ceph-mon/leader -- ceph mgr module ls | grep dashboard
+    # Expected output:
+    dashboard          on
+
+    $ juju exec -u ceph-mon/leader -- ceph mgr services | grep dashboard
+    # Expected output:
+    "dashboard": "https://10.149.54.80:8443/",
+    ```
+    Refer to the _**Ceph RESTful API Documentation**_ above for the detailed usage of Ceph API.
+
+## Setup Steps
+
+### 1. Deploy and Configure Grafana Agent
+Deploy Grafana Agent and connect to COS:
+```bash
+# Deploy grafana-agent
+juju deploy grafana-agent
+
+# Relate to ceph-mon
+juju relate grafana-agent ceph-mon
+
+# Connect to COS (assumes offers exist)
+juju relate grafana-agent loki-logging
+```
+
+### 2. Configure COS Alert Rules
+Switch to your COS model and deploy [cos-configuration-k8s](https://charmhub.io/cos-configuration-k8s):
+
+```bash
+# Switch to COS model
+juju switch cos
+
+# Deploy cos-configuration-k8s charm
+juju deploy cos-configuration-k8s cos-config \
+    --config git_repo=https://github.com/canonical/smoke-alerts \
+    --config git_branch=main \
+    --config git_depth=1 \
+    --config loki_alert_rules_path=rules/prod/loki/ \
+
+# Relate to Loki and Prometheus
+juju relate loki cos-config
+```
+After this point, the alert rules in [ceph_dashboard_rules.rule](../rules/prod/loki/ceph_dashboard_rules.rule) will be applicable.
+
+## API Log Source and Format
+The HTTP access logs for Ceph API are recorded in `/var/log/ceph/ceph-mgr.*.log` file in the `ceph-mon` machine. Example log entries:
+```log
+2026-01-09T01:06:40.013+0000 7f7b3f7ee640  0 [dashboard INFO request] [::ffff:10.149.54.71:55826] [POST] [400] [0.150s] [85.0B] [0f83d360-51db-4bad-aa44-0269b71aef10] /api/auth
+2026-01-09T01:33:34.696+0000 7f7b3b7e6640  0 [dashboard INFO request] [::ffff:10.149.54.71:60974] [POST] [201] [0.380s] [1.3K] [dbcce1e9-76f6-40d5-a66f-70e4098915d3] /api/auth
+2026-01-09T01:34:48.002+0000 7f7b3f7ee640  0 [dashboard INFO request] [::ffff:10.149.54.71:41564] [GET] [200] [0.012s] [admin] [1.3K] /api/health/minimal
+2026-01-09T02:00:50.025+0000 7f7b3e7ec640  0 [dashboard INFO request] [::ffff:10.149.54.71:56588] [GET] [200] [0.011s] [admin] [37.9K] /api/pool
+2026-01-09T02:02:40.531+0000 7f7b3d7ea640  0 [dashboard INFO request] [::ffff:10.149.54.71:59216] [GET] [200] [0.007s] [admin] [14.1K] /api/osd
+2026-01-09T02:11:41.658+0000 7f7b3c7e8640  0 [dashboard INFO request] [::ffff:10.149.54.71:33288] [POST] [201] [1.640s] [admin] [4.0B] /api/pool
+2026-01-09T02:11:50.548+0000 7f7b3f7ee640  0 [dashboard INFO request] [::ffff:10.149.54.71:44014] [PUT] [200] [1.558s] [admin] [4.0B] /api/pool/test-api-pool
+2026-01-09T02:14:49.488+0000 7f7b3b7e6640  0 [dashboard INFO request] [::ffff:10.149.54.71:38614] [GET] [200] [0.008s] [admin] [39.9K] /api/pool
+2026-01-09T02:15:42.429+0000 7f7b3f7ee640  0 [dashboard INFO request] [::ffff:10.149.54.71:44018] [DELETE] [400] [0.025s] [admin] [182.0B] /api/pool/test-api-pool
+2026-01-09T02:18:38.259+0000 7f7b3c7e8640  0 [dashboard INFO request] [::ffff:10.149.54.71:53300] [GET] [404] [0.007s] [admin] [513.0B] /api/random
+2026-01-09T02:18:49.095+0000 7f7b3b7e6640  0 [dashboard INFO request] [::ffff:10.149.54.71:45060] [GET] [200] [0.006s] [admin] [73.0B] /api/osd/flags
+```
+
+
+

--- a/rules/prod/loki/ceph_dashboard_rules.rule
+++ b/rules/prod/loki/ceph_dashboard_rules.rule
@@ -6,7 +6,7 @@ groups:
       expr: |-
         (
           (
-            sum by (juju_model)(
+            sum by (juju_model, juju_unit)(
               rate(
                 {filename=~"/var/log/ceph/ceph-mgr.*"}
                 |= "[dashboard INFO request]"
@@ -17,7 +17,7 @@ groups:
               )
             )
             /
-            sum by (juju_model)(
+            sum by (juju_model, juju_unit)(
               rate(
                 {filename=~"/var/log/ceph/ceph-mgr.*"}
                 |= "[dashboard INFO request]"
@@ -42,7 +42,7 @@ groups:
       expr: |-
         (
           (
-            sum by (juju_model)(
+            sum by (juju_model, juju_unit)(
               rate(
                 {filename=~"/var/log/ceph/ceph-mgr.*"}
                 |= "[dashboard INFO request]"
@@ -53,7 +53,7 @@ groups:
               )
             )
             /
-            sum by (juju_model)(
+            sum by (juju_model, juju_unit)(
               rate(
                 {filename=~"/var/log/ceph/ceph-mgr.*"}
                 |= "[dashboard INFO request]"
@@ -78,7 +78,7 @@ groups:
       expr: |-
         (
           (
-            sum by (juju_model)(
+            sum by (juju_model, juju_unit)(
               rate(
                 {filename=~"/var/log/ceph/ceph-mgr.*"}
                 |= "[dashboard INFO request]"
@@ -89,7 +89,7 @@ groups:
               )
             )
             /
-            sum by (juju_model)(
+            sum by (juju_model, juju_unit)(
               rate(
                 {filename=~"/var/log/ceph/ceph-mgr.*"}
                 |= "[dashboard INFO request]"
@@ -114,7 +114,7 @@ groups:
       expr: |-
         (
           (
-            sum by (juju_model)(
+            sum by (juju_model, juju_unit)(
               rate(
                 {filename=~"/var/log/ceph/ceph-mgr.*"}
                 |= "[dashboard INFO request]"
@@ -125,7 +125,7 @@ groups:
               )
             )
             /
-            sum by (juju_model)(
+            sum by (juju_model, juju_unit)(
               rate(
                 {filename=~"/var/log/ceph/ceph-mgr.*"}
                 |= "[dashboard INFO request]"

--- a/rules/prod/loki/ceph_dashboard_rules.rule
+++ b/rules/prod/loki/ceph_dashboard_rules.rule
@@ -38,6 +38,42 @@ groups:
         description: Ceph API failure rate in model {{ $labels.juju_model }} is {{ $value }}% over the last hour, exceeding the 20% threshold.
         summary: High Ceph API failure rate detected
 
+    - alert: CephAPIFailureRateCritical
+      expr: |-
+        (
+          (
+            sum by (juju_model, juju_application, juju_unit)(
+              rate(
+                {filename=~"/var/log/ceph/ceph-mgr.*"}
+                |= "[dashboard INFO request]"
+                != "/api/auth"
+                | pattern `[dashboard INFO request] [<_>] [<method>] [<status_code>] <_>`
+                | status_code=~"(4|5).."
+                [1h]
+              )
+            )
+            /
+            sum by (juju_model, juju_application, juju_unit)(
+              rate(
+                {filename=~"/var/log/ceph/ceph-mgr.*"}
+                |= "[dashboard INFO request]"
+                != "/api/auth"
+                | pattern `[dashboard INFO request] [<_>] [<method>] [<status_code>] <_>`
+                | status_code=~"(1|2|3|4|5).."
+                [1h]
+              )
+            )
+          ) * 100
+        ) > 70
+      for: 5m
+      labels:
+        alert_type: api_failure_rate
+        service: ceph-dashboard
+        severity: critical
+      annotations:
+        description: Ceph API failure rate in model {{ $labels.juju_model }} is {{ $value }}% over the last hour, exceeding the 70% threshold.
+        summary: Critical Ceph API failure rate detected
+
     - alert: CephAuthFailureRateHigh
       expr: |-
         (
@@ -73,3 +109,39 @@ groups:
       annotations:
         description: Ceph authentication failure rate in model {{ $labels.juju_model }} is {{ $value }}% over the last hour, exceeding the 20% threshold.
         summary: High Ceph authentication failure rate detected
+
+    - alert: CephAuthFailureRateCritical
+      expr: |-
+        (
+          (
+            sum by (juju_model, juju_application, juju_unit)(
+              rate(
+                {filename=~"/var/log/ceph/ceph-mgr.*"}
+                |= "[dashboard INFO request]"
+                |= "/api/auth"
+                | pattern `[dashboard INFO request] [<_>] [<method>] [<status_code>] <_>`
+                | status_code=~"(4|5).."
+                [1h]
+              )
+            )
+            /
+            sum by (juju_model, juju_application, juju_unit)(
+              rate(
+                {filename=~"/var/log/ceph/ceph-mgr.*"}
+                |= "[dashboard INFO request]"
+                |= "/api/auth"
+                | pattern `[dashboard INFO request] [<_>] [<method>] [<status_code>] <_>`
+                | status_code=~"(1|2|3|4|5).."
+                [1h]
+              )
+            )
+          ) * 100
+        ) > 70
+      for: 5m
+      labels:
+        alert_type: auth_failure_rate
+        service: ceph-dashboard
+        severity: critical
+      annotations:
+        description: Ceph authentication failure rate in model {{ $labels.juju_model }} is {{ $value }}% over the last hour, exceeding the 70% threshold.
+        summary: Critical Ceph authentication failure rate detected

--- a/rules/prod/loki/ceph_dashboard_rules.rule
+++ b/rules/prod/loki/ceph_dashboard_rules.rule
@@ -6,23 +6,23 @@ groups:
       expr: |-
         (
           (
-            sum by (juju_model, juju_application, juju_unit)(
+            sum by (juju_model)(
               rate(
                 {filename=~"/var/log/ceph/ceph-mgr.*"}
                 |= "[dashboard INFO request]"
                 != "/api/auth"
-                | pattern `[dashboard INFO request] [<_>] [<method>] [<status_code>] <_>`
+                | pattern `<_> [dashboard INFO request] [<_>] [<method>] [<status_code>] <_>`
                 | status_code=~"(4|5).."
                 [1h]
               )
             )
             /
-            sum by (juju_model, juju_application, juju_unit)(
+            sum by (juju_model)(
               rate(
                 {filename=~"/var/log/ceph/ceph-mgr.*"}
                 |= "[dashboard INFO request]"
                 != "/api/auth"
-                | pattern `[dashboard INFO request] [<_>] [<method>] [<status_code>] <_>`
+                | pattern `<_> [dashboard INFO request] [<_>] [<method>] [<status_code>] <_>`
                 | status_code=~"(1|2|3|4|5).."
                 [1h]
               )
@@ -42,23 +42,23 @@ groups:
       expr: |-
         (
           (
-            sum by (juju_model, juju_application, juju_unit)(
+            sum by (juju_model)(
               rate(
                 {filename=~"/var/log/ceph/ceph-mgr.*"}
                 |= "[dashboard INFO request]"
                 != "/api/auth"
-                | pattern `[dashboard INFO request] [<_>] [<method>] [<status_code>] <_>`
+                | pattern `<_> [dashboard INFO request] [<_>] [<method>] [<status_code>] <_>`
                 | status_code=~"(4|5).."
                 [1h]
               )
             )
             /
-            sum by (juju_model, juju_application, juju_unit)(
+            sum by (juju_model)(
               rate(
                 {filename=~"/var/log/ceph/ceph-mgr.*"}
                 |= "[dashboard INFO request]"
                 != "/api/auth"
-                | pattern `[dashboard INFO request] [<_>] [<method>] [<status_code>] <_>`
+                | pattern `<_> [dashboard INFO request] [<_>] [<method>] [<status_code>] <_>`
                 | status_code=~"(1|2|3|4|5).."
                 [1h]
               )
@@ -78,23 +78,23 @@ groups:
       expr: |-
         (
           (
-            sum by (juju_model, juju_application, juju_unit)(
+            sum by (juju_model)(
               rate(
                 {filename=~"/var/log/ceph/ceph-mgr.*"}
                 |= "[dashboard INFO request]"
                 |= "/api/auth"
-                | pattern `[dashboard INFO request] [<_>] [<method>] [<status_code>] <_>`
+                | pattern `<_> [dashboard INFO request] [<_>] [<method>] [<status_code>] <_>`
                 | status_code=~"(4|5).."
                 [1h]
               )
             )
             /
-            sum by (juju_model, juju_application, juju_unit)(
+            sum by (juju_model)(
               rate(
                 {filename=~"/var/log/ceph/ceph-mgr.*"}
                 |= "[dashboard INFO request]"
                 |= "/api/auth"
-                | pattern `[dashboard INFO request] [<_>] [<method>] [<status_code>] <_>`
+                | pattern `<_> [dashboard INFO request] [<_>] [<method>] [<status_code>] <_>`
                 | status_code=~"(1|2|3|4|5).."
                 [1h]
               )
@@ -114,23 +114,23 @@ groups:
       expr: |-
         (
           (
-            sum by (juju_model, juju_application, juju_unit)(
+            sum by (juju_model)(
               rate(
                 {filename=~"/var/log/ceph/ceph-mgr.*"}
                 |= "[dashboard INFO request]"
                 |= "/api/auth"
-                | pattern `[dashboard INFO request] [<_>] [<method>] [<status_code>] <_>`
+                | pattern `<_> [dashboard INFO request] [<_>] [<method>] [<status_code>] <_>`
                 | status_code=~"(4|5).."
                 [1h]
               )
             )
             /
-            sum by (juju_model, juju_application, juju_unit)(
+            sum by (juju_model)(
               rate(
                 {filename=~"/var/log/ceph/ceph-mgr.*"}
                 |= "[dashboard INFO request]"
                 |= "/api/auth"
-                | pattern `[dashboard INFO request] [<_>] [<method>] [<status_code>] <_>`
+                | pattern `<_> [dashboard INFO request] [<_>] [<method>] [<status_code>] <_>`
                 | status_code=~"(1|2|3|4|5).."
                 [1h]
               )

--- a/rules/prod/loki/ceph_dashboard_rules.rule
+++ b/rules/prod/loki/ceph_dashboard_rules.rule
@@ -1,0 +1,75 @@
+namespace: ceph_dashboard_rules
+groups:
+  - name: ceph-dashboard-api-failures
+    rules:
+    - alert: CephAPIFailureRateHigh
+      expr: |-
+        (
+          (
+            sum by (juju_model, juju_application, juju_unit)(
+              rate(
+                {filename=~"/var/log/ceph/ceph-mgr.*"}
+                |= "[dashboard INFO request]"
+                != "/api/auth"
+                | pattern `[dashboard INFO request] [<_>] [<method>] [<status_code>] <_>`
+                | status_code=~"(4|5).."
+                [1h]
+              )
+            )
+            /
+            sum by (juju_model, juju_application, juju_unit)(
+              rate(
+                {filename=~"/var/log/ceph/ceph-mgr.*"}
+                |= "[dashboard INFO request]"
+                != "/api/auth"
+                | pattern `[dashboard INFO request] [<_>] [<method>] [<status_code>] <_>`
+                | status_code=~"(1|2|3|4|5).."
+                [1h]
+              )
+            )
+          ) * 100
+        ) > 20
+      for: 5m
+      labels:
+        alert_type: api_failure_rate
+        service: ceph-dashboard
+        severity: warning
+      annotations:
+        description: Ceph API failure rate in model {{ $labels.juju_model }} is {{ $value }}% over the last hour, exceeding the 20% threshold.
+        summary: High Ceph API failure rate detected
+
+    - alert: CephAuthFailureRateHigh
+      expr: |-
+        (
+          (
+            sum by (juju_model, juju_application, juju_unit)(
+              rate(
+                {filename=~"/var/log/ceph/ceph-mgr.*"}
+                |= "[dashboard INFO request]"
+                |= "/api/auth"
+                | pattern `[dashboard INFO request] [<_>] [<method>] [<status_code>] <_>`
+                | status_code=~"(4|5).."
+                [1h]
+              )
+            )
+            /
+            sum by (juju_model, juju_application, juju_unit)(
+              rate(
+                {filename=~"/var/log/ceph/ceph-mgr.*"}
+                |= "[dashboard INFO request]"
+                |= "/api/auth"
+                | pattern `[dashboard INFO request] [<_>] [<method>] [<status_code>] <_>`
+                | status_code=~"(1|2|3|4|5).."
+                [1h]
+              )
+            )
+          ) * 100
+        ) > 20
+      for: 5m
+      labels:
+        alert_type: auth_failure_rate
+        service: ceph-dashboard
+        severity: warning
+      annotations:
+        description: Ceph authentication failure rate in model {{ $labels.juju_model }} is {{ $value }}% over the last hour, exceeding the 20% threshold.
+        summary: High Ceph authentication failure rate detected

--- a/rules/prod/prometheus/ceph_rules.rule
+++ b/rules/prod/prometheus/ceph_rules.rule
@@ -1,0 +1,53 @@
+groups:
+  - name: ceph_osd_health
+    rules:
+      - alert: CephOSDDownSpecific
+        expr: ceph_osd_up == 0
+        for: 10m
+        labels:
+          severity: warning
+          type: ceph_default
+          alert_type: osd_down
+          service: ceph-osd
+        annotations:
+          summary: "OSD {{ $labels.ceph_daemon }} is down"
+          description: "OSD {{ $labels.ceph_daemon }} ({{ $labels.hostname }}) has been down for more than 10 minutes."
+
+      - alert: CephOSDCommitLatencyHigh
+        expr: ceph_osd_commit_latency_ms > 50
+        for: 10m
+        labels:
+          severity: warning
+          type: ceph_default
+          alert_type: osd_latency
+          service: ceph-osd
+        annotations:
+          summary: "OSD {{ $labels.ceph_daemon }} commit latency high"
+          description: "OSD {{ $labels.ceph_daemon }} ({{ $labels.hostname }}) commit latency is {{ $value | printf \"%.0f\" }}ms, exceeding 50ms threshold for more than 10 minutes."
+
+      - alert: CephOSDCommitLatencyCritical
+        expr: ceph_osd_commit_latency_ms > 200
+        for: 10m
+        labels:
+          severity: critical
+          type: ceph_default
+          alert_type: osd_latency
+          service: ceph-osd
+        annotations:
+          summary: "OSD {{ $labels.ceph_daemon }} commit latency critical"
+          description: "OSD {{ $labels.ceph_daemon }} ({{ $labels.hostname }}) commit latency is {{ $value | printf \"%.0f\" }}ms, exceeding 200ms threshold for more than 10 minutes."
+
+      - alert: CephOSDCommitLatencyOutlier
+        expr: |
+          (ceph_osd_commit_latency_ms > 50)
+          and
+          (ceph_osd_commit_latency_ms > on() group_left 2 * avg(ceph_osd_commit_latency_ms))
+        for: 10m
+        labels:
+          severity: warning
+          type: ceph_default
+          alert_type: osd_latency
+          service: ceph-osd
+        annotations:
+          summary: "OSD {{ $labels.ceph_daemon }} commit latency outlier"
+          description: "OSD {{ $labels.ceph_daemon }} is experiencing commit latency of {{ $value | printf \"%.0f\" }}ms which is significantly higher than the cluster average."

--- a/rules/prod/prometheus/ceph_rules.rule
+++ b/rules/prod/prometheus/ceph_rules.rule
@@ -15,6 +15,23 @@ groups:
           summary: "OSD {{ $labels.ceph_daemon }} is down"
           description: "OSD {{ $labels.ceph_daemon }} ({{ $labels.hostname }}) has been down for more than 10 minutes."
 
+      - alert: CephOSDDownHighOnHost
+        expr: |
+          (
+            count by (hostname) ((ceph_osd_up == 0) * on(ceph_daemon) group_left(hostname) ceph_osd_metadata)
+            /
+            count by (hostname) (ceph_osd_metadata)
+          ) * 100 >= 10
+        for: 10m
+        labels:
+          severity: critical
+          type: ceph_default
+          alert_type: osd_down
+          service: ceph-osd
+        annotations:
+            summary: "Critical OSD loss in Host {{ $labels.hostname }}"
+            description: "{{ $value | printf \"%.1f\" }}% of OSDs in host {{ $labels.hostname }} has been down for more than 10 minutes."
+
       - alert: CephOSDCommitLatencyHigh
         expr: |
           (ceph_osd_commit_latency_ms > 50)

--- a/rules/prod/prometheus/ceph_rules.rule
+++ b/rules/prod/prometheus/ceph_rules.rule
@@ -2,7 +2,9 @@ groups:
   - name: ceph_osd_health
     rules:
       - alert: CephOSDDownSpecific
-        expr: ceph_osd_up == 0
+        expr: |
+          (ceph_osd_up == 0)
+          * on(ceph_daemon) group_left(hostname) ceph_osd_metadata
         for: 10m
         labels:
           severity: warning
@@ -14,7 +16,9 @@ groups:
           description: "OSD {{ $labels.ceph_daemon }} ({{ $labels.hostname }}) has been down for more than 10 minutes."
 
       - alert: CephOSDCommitLatencyHigh
-        expr: ceph_osd_commit_latency_ms > 50
+        expr: |
+          (ceph_osd_commit_latency_ms > 50)
+          * on(ceph_daemon) group_left(hostname) ceph_osd_metadata
         for: 10m
         labels:
           severity: warning
@@ -26,7 +30,9 @@ groups:
           description: "OSD {{ $labels.ceph_daemon }} ({{ $labels.hostname }}) commit latency is {{ $value | printf \"%.0f\" }}ms, exceeding 50ms threshold for more than 10 minutes."
 
       - alert: CephOSDCommitLatencyCritical
-        expr: ceph_osd_commit_latency_ms > 200
+        expr: |
+          (ceph_osd_commit_latency_ms > 200)
+          * on(ceph_daemon) group_left(hostname) ceph_osd_metadata
         for: 10m
         labels:
           severity: critical
@@ -39,9 +45,12 @@ groups:
 
       - alert: CephOSDCommitLatencyOutlier
         expr: |
-          (ceph_osd_commit_latency_ms > 50)
-          and
-          (ceph_osd_commit_latency_ms > on() group_left 2 * avg(ceph_osd_commit_latency_ms))
+          (
+            (ceph_osd_commit_latency_ms > 50)
+            and
+            (ceph_osd_commit_latency_ms > on() group_left 2 * avg(ceph_osd_commit_latency_ms))
+          )
+          * on(ceph_daemon) group_left(hostname) ceph_osd_metadata
         for: 10m
         labels:
           severity: warning
@@ -50,4 +59,4 @@ groups:
           service: ceph-osd
         annotations:
           summary: "OSD {{ $labels.ceph_daemon }} commit latency outlier"
-          description: "OSD {{ $labels.ceph_daemon }} is experiencing commit latency of {{ $value | printf \"%.0f\" }}ms which is significantly higher than the cluster average."
+          description: "OSD {{ $labels.ceph_daemon }} ({{ $labels.hostname }}) is experiencing commit latency of {{ $value | printf \"%.0f\" }}ms which is significantly higher than the cluster average."

--- a/rules/prod/prometheus/ceph_rules.rule
+++ b/rules/prod/prometheus/ceph_rules.rule
@@ -15,13 +15,13 @@ groups:
           summary: "OSD {{ $labels.ceph_daemon }} is down"
           description: "OSD {{ $labels.ceph_daemon }} ({{ $labels.hostname }}) has been down for more than 10 minutes."
 
-      - alert: CephOSDDownHighOnHost
+      - alert: CephOSDDownAllOnHost
         expr: |
           (
             count by (hostname) ((ceph_osd_up == 0) * on(ceph_daemon) group_left(hostname) ceph_osd_metadata)
             /
             count by (hostname) (ceph_osd_metadata)
-          ) * 100 >= 10
+          ) == 1
         for: 10m
         labels:
           severity: critical
@@ -29,8 +29,8 @@ groups:
           alert_type: osd_down
           service: ceph-osd
         annotations:
-            summary: "Critical OSD loss in Host {{ $labels.hostname }}"
-            description: "{{ $value | printf \"%.1f\" }}% of OSDs in host {{ $labels.hostname }} has been down for more than 10 minutes."
+            summary: "All OSDs down in Host {{ $labels.hostname }}"
+            description: "All OSDs in host {{ $labels.hostname }} have been down for more than 10 minutes."
 
       - alert: CephOSDCommitLatencyHigh
         expr: |

--- a/rules/prod/prometheus/ceph_rules.rule
+++ b/rules/prod/prometheus/ceph_rules.rule
@@ -34,7 +34,7 @@ groups:
 
       - alert: CephOSDCommitLatencyHigh
         expr: |
-          (ceph_osd_commit_latency_ms > 50)
+          (ceph_osd_commit_latency_ms > 150)
           * on(ceph_daemon) group_left(hostname) ceph_osd_metadata
         for: 10m
         labels:
@@ -44,11 +44,11 @@ groups:
           service: ceph-osd
         annotations:
           summary: "OSD {{ $labels.ceph_daemon }} commit latency high"
-          description: "OSD {{ $labels.ceph_daemon }} ({{ $labels.hostname }}) commit latency is {{ $value | printf \"%.0f\" }}ms, exceeding 50ms threshold for more than 10 minutes."
+          description: "OSD {{ $labels.ceph_daemon }} ({{ $labels.hostname }}) commit latency is {{ $value | printf \"%.0f\" }}ms, exceeding 150ms threshold for more than 10 minutes."
 
       - alert: CephOSDCommitLatencyCritical
         expr: |
-          (ceph_osd_commit_latency_ms > 200)
+          (ceph_osd_commit_latency_ms > 300)
           * on(ceph_daemon) group_left(hostname) ceph_osd_metadata
         for: 10m
         labels:
@@ -58,12 +58,12 @@ groups:
           service: ceph-osd
         annotations:
           summary: "OSD {{ $labels.ceph_daemon }} commit latency critical"
-          description: "OSD {{ $labels.ceph_daemon }} ({{ $labels.hostname }}) commit latency is {{ $value | printf \"%.0f\" }}ms, exceeding 200ms threshold for more than 10 minutes."
+          description: "OSD {{ $labels.ceph_daemon }} ({{ $labels.hostname }}) commit latency is {{ $value | printf \"%.0f\" }}ms, exceeding 300ms threshold for more than 10 minutes."
 
       - alert: CephOSDCommitLatencyOutlier
         expr: |
           (
-            (ceph_osd_commit_latency_ms > 50)
+            (ceph_osd_commit_latency_ms > 150)
             and
             (ceph_osd_commit_latency_ms > on() group_left 2 * avg(ceph_osd_commit_latency_ms))
           )


### PR DESCRIPTION
This PR adds: 

## 1. Loki rules and corresponding documentation for charmed Ceph

See [context](https://docs.google.com/document/d/1v0F6MNzYrrXizYcztHwfwSOeYuAPvFJW_HOcigzPlJs/edit?tab=t.3s8ao9wes17g).

The rules are to alert on [Ceph RESTful API ](https://docs.ceph.com/en/latest/mgr/ceph_api/) failure rate (more than \<threshold\> % in last 1h - as per Smoke detector's requirement).
    *Note*: Ceph API is only for control plane operations, not data plane operations.    
    
Example alerts from dashboard:
    <img width="1683" height="697" alt="image" src="https://github.com/user-attachments/assets/81fe68de-62b6-48a8-bda3-e6ff61f41489" />
    <img width="1565" height="595" alt="image" src="https://github.com/user-attachments/assets/0cbb59f8-f90c-47cd-9e8f-4fe3dc781795" />


## 2. Prometheus rules for OSD down and OSD commit latency:
   See [context](https://docs.google.com/document/d/1v0F6MNzYrrXizYcztHwfwSOeYuAPvFJW_HOcigzPlJs/edit?tab=t.gkkrppiuyi3s)
   - A rule to trigger an alert per each OSD down, for example:
   
<img width="1542" height="1027" alt="osddown_2" src="https://github.com/user-attachments/assets/310964ed-dce6-4725-9f04-a0332e4bbc9f" />

   - Rule for all OSDs down in a host, for example:
   
<img width="1552" height="823" alt="image" src="https://github.com/user-attachments/assets/21fb641b-7c66-4a82-a508-a851931b8b3c" />

 
   - Rules for high commit latency found (> threshold)
   - Rule for detecting outlier OSD with higher commit latency than 2x average
