### PR TITLE
Add Loki rules for Landscape API failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,6 @@ This repository should be referenced by the [cos-configuration-k8s](https://char
 See reference and audit logging setup guides for each use case:
 - [Charmed OpenStack](docs/setup_guides/charmed_openstack_setup.md)
 - [Canonical K8s](docs/setup_guides/canonical_k8s_setup.md)
-- [Landscape Server](docs/setup_guides/landscape_server_referencs.md)
+- [Landscape Server](docs/setup_guides/landscape_server_references.md)
 
 See all alert rules and example log references in [rules.md](docs/rules.md) and [references.md](docs/references.md).

--- a/README.md
+++ b/README.md
@@ -6,11 +6,13 @@ Contains "smoke-alarm" rules for these use cases:
 - canonical k8s
 - sunbeam
 - charmed openstack
+- landscape server
 
 This repository should be referenced by the [cos-configuration-k8s](https://charmhub.io/cos-configuration-k8s) charm to forward alert rules to Canonical Observability Stack (COS).
 
-See audit logging setup guides for each use case:
+See reference and audit logging setup guides for each use case:
 - [Charmed OpenStack](docs/setup_guides/charmed_openstack_setup.md)
 - [Canonical K8s](docs/setup_guides/canonical_k8s_setup.md)
+- [Landscape Server](docs/setup_guides/landscape_server_referencs.md)
 
 See all alert rules and example log references in [rules.md](docs/rules.md) and [references.md](docs/references.md).

--- a/docs/references.md
+++ b/docs/references.md
@@ -207,3 +207,45 @@ In `/var/log/kubernetes/audit.log`:
 Alert will trigger when a single user exceeds 50 requests/second sustained over 10 minutes, indicating possible compromised service account or runaway application.
 
 ---
+
+## Landscape Server
+
+These log lines contain HTTP status codes indicating API failures (4xx or 5xx responses) from various Landscape Server components. The Landscape Server logs are located in `/var/log/landscape-server/` directory.
+
+### LandscapeAPIFailureRateHigh and LandscapeAPIFailureRateCritical
+
+**Example log lines:**
+
+From `api.log`:
+```
+Jan 18 23:43:07 api-1 INFO  "127.0.0.1" - - [18/Jan/2026:23:43:06 +0000] "GET /metrics?action=MissingAction&access_key_id=Unknown HTTP/1.1" 404 57 "-" "GrafanaAgent/v0.40.4 (static; linux; binary)"
+```
+
+From `appserver.log`:
+```
+Jan 18 23:42:53 appserver-1 INFO  GET /metrics method=GET path=/metrics status=404 duration_ms=110.058 ip=127.0.0.1 proto=HTTP/1.1 length=10610 ua="GrafanaAgent/v0.40.4 (static; linux; binary)" request_id=a9cc3b7c-39fc-4b7c-8301-e346d47364d7
+```
+
+From `message-server.log`:
+```
+Jan 18 23:52:03 message-server-2 INFO  "10.17.2.199" - - [18/Jan/2026:23:52:02 +0000] "POST /message-system HTTP/1.1" 200 235 "-" "landscape-client/24.02-0ubuntu5.7"
+```
+
+From `pingserver.log`:
+```
+Jan 18 23:52:09 pingserver-2 INFO  "::ffff:10.17.2.199" - - [18/Jan/2026:23:52:08 +0000] "POST /ping HTTP/1.1" 200 15 "-" "PycURL/7.45.3 libcurl/8.5.0 GnuTLS/3.8.3 zlib/1.3 brotli/1.1.0 zstd/1.5.5 libidn2/2.3.7 libpsl/0.21.2 (+libidn2/2.3.7) libssh/0.10.6/openssl/zlib nghttp2/1.59.0 librtmp/2.3 OpenLDAP/2.6.7"
+```
+
+From `package-upload.log`:
+```
+Jan 18 23:43:13 package-upload-1 INFO  "127.0.0.1" - - [18/Jan/2026:23:43:12 +0000] "GET /metrics HTTP/1.1" 404 57 "-" "GrafanaAgent/v0.40.4 (static; linux; binary)"
+```
+
+From `package-search.log`:
+```
+Jan 19 00:45:13 package-search INFO  package-search 2026/01/19 00:45:13 127.0.0.1:45934 - /UpdateUsns 200: succeeded (took 136.314µs)
+```
+
+Alert will trigger if the proportion of log lines with 4xx or 5xx status codes exceeds a threshold (20% for Warning, 70% for Critical) over a 1-hour period across any of these log files.
+
+---

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -98,3 +98,12 @@ An overview of all alert rules.
 | **CanonicalK8sUserAccessFailuresCritical** | User has ≥5 access failures in 10 minutes | Critical |
 | **CanonicalK8sAPIRequestBurst** | API request rate over 10 minutes exceeds 3x the 1-hour baseline | Warning |
 | **CanonicalK8sHighRequestRatePerUser** | User exceeds 50 requests/second over 10 minutes | Warning |
+
+## Landscape Server Alert Rules
+
+### Loki Alerts
+
+| Alert Name | Trigger Condition | Severity |
+|------------|-------------------|----------|
+| **LandscapeAPIFailureRateHigh** | API failure rate >20% across all services over 1 hour | Warning |
+| **LandscapeAPIFailureRateCritical** | API failure rate >70% across all services over 1 hour | Critical |

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -105,5 +105,5 @@ An overview of all alert rules.
 
 | Alert Name | Trigger Condition | Severity |
 |------------|-------------------|----------|
-| **LandscapeAPIFailureRateHigh** | API failure rate >20% across all services over 1 hour | Warning |
-| **LandscapeAPIFailureRateCritical** | API failure rate >70% across all services over 1 hour | Critical |
+| **LandscapeAPIFailureRateHigh** | API failure rate >20% across all services over last 1 hour | Warning |
+| **LandscapeAPIFailureRateCritical** | API failure rate >70% across all services over last 1 hour | Critical |

--- a/docs/setup_guides/landscape_server_references.md
+++ b/docs/setup_guides/landscape_server_references.md
@@ -1,0 +1,83 @@
+# Landscape Server API Log References
+
+## Overview
+The rules defined in [landscape_server_rules.rule](../../rules/prod/loki/landscape_server_rules.rule) are to monitor the API access failure rates (via HTTP status codes) of a Landscape Server using [Landscape Server logs](https://documentation.ubuntu.com/landscape/reference/logs/logs/#server-logs).
+
+Log files with HTTP Response codes which can be used as sources for these rules:
+
+`api.log`
+`appserver.log`
+`message-server.log`
+`pingserver.log`
+`package-upload.log`
+`package-search.log`
+
+## Prerequisites
+
+- [Landscape Server](https://documentation.ubuntu.com/landscape/how-to-guides/landscape-installation-and-set-up/juju-installation/#) deployment via Juju
+- [COS](https://documentation.ubuntu.com/observability/latest/) deployment
+
+## Setup Steps
+
+### 1. Deploy and Configure Grafana Agent
+
+Deploy Grafana Agent matching your Landscape Server base version:
+
+```bash
+# Deploy grafana-agent
+juju deploy grafana-agent --base ubuntu@<match-landscape-server-base>
+
+# Relate to landscape-server
+juju relate grafana-agent landscape-server
+
+# Connect to COS (assumes offer exists)
+juju relate grafana-agent loki-logging
+```
+
+### 2. Configure COS Alert Rules
+Switch to your COS model and deploy [cos-configuration-k8s](https://charmhub.io/cos-configuration-k8s):
+
+```bash
+# Switch to COS model
+juju switch cos
+
+# Deploy cos-configuration-k8s charm
+juju deploy cos-configuration-k8s cos-config \
+    --config git_repo=https://github.com/canonical/smoke-alerts \
+    --config git_branch=main \
+    --config git_depth=1 \
+    --config loki_alert_rules_path=rules/prod/loki/ \
+
+# Relate to Loki
+juju relate loki cos-config
+```
+
+After this point, the alert rules in [landscape_server_rules.rule](../../rules/prod/loki/landscape_server_rules.rule) will be applicable.
+
+## API Log Source and Format
+The Landscape Server API logs are located in `/var/log/landscape-server/` directory. The relevant log files include:
+
+From `api.log`:
+```
+Jan 18 23:43:07 api-1 INFO  \"127.0.0.1\" - - [18/Jan/2026:23:43:06 +0000] \"GET /metrics?action=MissingAction&access_key_id=Unknown HTTP/1.1\" 404 57 \"-\" \"GrafanaAgent/v0.40.4 (static; linux; binary)\"
+```
+From `appserver.log`:
+```
+Jan 18 23:42:53 appserver-1 INFO  GET /metrics method=GET path=/metrics status=404 duration_ms=110.058 ip=127.0.0.1 proto=HTTP/1.1 length=10610 ua="GrafanaAgent/v0.40.4 (static; linux; binary)" request_id=a9cc3b7c-39fc-4b7c-8301-e346d47364d7
+```
+From `message-server.log`:
+```
+Jan 18 23:52:03 message-server-2 INFO  \"10.17.2.199\" - - [18/Jan/2026:23:52:02 +0000] \"POST /message-system HTTP/1.1\" 200 235 \"-\" \"landscape-client/24.02-0ubuntu5.7\"
+```
+From `pingserver.log`:
+```
+Jan 18 23:52:09 pingserver-2 INFO  \"::ffff:10.17.2.199\" - - [18/Jan/2026:23:52:08 +0000] \"POST /ping HTTP/1.1\" 200 15 \"-\" \"PycURL/7.45.3 libcurl/8.5.0 GnuTLS/3.8.3 zlib/1.3 brotli/1.1.0 zstd/1.5.5 libidn2/2.3.7 libpsl/0.21.2 (+libidn2/2.3.7) libssh/0.10.6/openssl/zlib nghttp2/1.59.0 librtmp/2.3 OpenLDAP/2.6.7\"
+```
+From `package-upload.log`:
+```
+Jan 18 23:43:13 package-upload-1 INFO  \"127.0.0.1\" - - [18/Jan/2026:23:43:12 +0000] \"GET /metrics HTTP/1.1\" 404 57 \"-\" \"GrafanaAgent/v0.40.4 (static; linux; binary)\"
+```
+From `package-search.log`:
+```
+Jan 19 00:45:13 package-search INFO  package-search 2026/01/19 00:45:13 127.0.0.1:45934 - /UpdateUsns 200: succeeded (took 136.314µs)
+```

--- a/rules/prod/loki/landscape_server_rules.rule
+++ b/rules/prod/loki/landscape_server_rules.rule
@@ -5,47 +5,45 @@ groups:
       - alert: LandscapeAPIFailureRateHigh
         expr: |-
           (
-            sum by (juju_model, filename) (
+            sum by (juju_model) (
               rate({filename=~"/var/log/landscape-server/(api|appserver|message-server|pingserver|package-upload|package-search).log"}
                 |~ `(\" [45][0-9]{2} |status=[45][0-9]{2}|[45][0-9]{2}:)` [1h])
               )
               /
-              sum by (juju_model, filename) (
+              sum by (juju_model) (
               rate({filename=~"/var/log/landscape-server/(api|appserver|message-server|pingserver|package-upload|package-search).log"}
                   |~ `(\" [0-9]{3} |status=[0-9]{3}|[0-9]{3}:)` [1h])
               )
           ) * 100 > 20
-        for: 5m
         labels:
           alert_type: api_failure_rate
           service: landscape
           severity: warning
         annotations:
           description: |
-            API failure rate for {{ $labels.filename }} in model {{ $labels.juju_model }}
-            is {{ $value | humanizePercentage }} over the last hour, exceeding the 20% threshold.
+            API failure rate for {{ $labels.juju_model }}
+            is {{ $value | printf "%.0f" }}% over the last hour, exceeding the 20% threshold.
           summary: "Landscape API error rate >20% in {{ $labels.juju_model }}"
 
       - alert: LandscapeAPIFailureRateCritical
         expr: |-
           (
-            sum by (juju_model, filename) (
+            sum by (juju_model) (
               rate({filename=~"/var/log/landscape-server/(api|appserver|message-server|pingserver|package-upload|package-search).log"}
                   |~ `(\" [45][0-9]{2} |status=[45][0-9]{2}|[45][0-9]{2}:)` [1h])
               )
               /
-              sum by (juju_model, filename) (
+              sum by (juju_model) (
               rate({filename=~"/var/log/landscape-server/(api|appserver|message-server|pingserver|package-upload|package-search).log"}
                   |~ `(\" [0-9]{3} |status=[0-9]{3}|[0-9]{3}:)` [1h])
               )
           ) * 100 > 70
-        for: 5m
         labels:
           alert_type: api_failure_rate
           service: landscape
           severity: critical
         annotations:
           description: |
-            CRITICAL: API failure rate for {{ $labels.filename }} in model {{ $labels.juju_model }}
-            is {{ $value | humanizePercentage }} over the last hour, exceeding the 70% threshold.
+            CRITICAL: API failure rate for {{ $labels.juju_model }}
+            is {{ $value | printf "%.0f" }}% over the last hour, exceeding the 70% threshold.
           summary: "Landscape API error rate >70% in {{ $labels.juju_model }}"

--- a/rules/prod/loki/landscape_server_rules.rule
+++ b/rules/prod/loki/landscape_server_rules.rule
@@ -1,0 +1,51 @@
+namespace: landscape_server_rules
+groups:
+  - name: landscape-server-api-failures
+    rules:
+      - alert: LandscapeAPIFailureRateHigh
+        expr: |-
+          (
+            sum by (juju_model, filename) (
+              rate({filename=~"/var/log/landscape-server/(api|appserver|message-server|pingserver|package-upload|package-search).log"}
+                |~ `(\" [45][0-9]{2} |status=[45][0-9]{2}|[45][0-9]{2}:)` [1h])
+              )
+              /
+              sum by (juju_model, filename) (
+              rate({filename=~"/var/log/landscape-server/(api|appserver|message-server|pingserver|package-upload|package-search).log"}
+                  |~ `(\" [0-9]{3} |status=[0-9]{3}|[0-9]{3}:)` [1h])
+              )
+          ) * 100 > 20
+        for: 5m
+        labels:
+          alert_type: api_failure_rate
+          service: landscape
+          severity: warning
+        annotations:
+          description: |
+            API failure rate for {{ $labels.filename }} in model {{ $labels.juju_model }}
+            is {{ $value | humanizePercentage }} over the last hour, exceeding the 20% threshold.
+          summary: "Landscape API error rate >20% in {{ $labels.juju_model }}"
+
+      - alert: LandscapeAPIFailureRateCritical
+        expr: |-
+          (
+            sum by (juju_model, filename) (
+              rate({filename=~"/var/log/landscape-server/(api|appserver|message-server|pingserver|package-upload|package-search).log"}
+                  |~ `(\" [45][0-9]{2} |status=[45][0-9]{2}|[45][0-9]{2}:)` [1h])
+              )
+              /
+              sum by (juju_model, filename) (
+              rate({filename=~"/var/log/landscape-server/(api|appserver|message-server|pingserver|package-upload|package-search).log"}
+                  |~ `(\" [0-9]{3} |status=[0-9]{3}|[0-9]{3}:)` [1h])
+              )
+          ) * 100 > 70
+        for: 5m
+        labels:
+          alert_type: api_failure_rate
+          service: landscape
+          severity: critical
+        annotations:
+          description: |
+            CRITICAL: API failure rate for {{ $labels.filename }} in model {{ $labels.juju_model }}
+            is {{ $value | humanizePercentage }} over the last hour, exceeding the 70% threshold.
+          summary: "Landscape API error rate >70% in {{ $labels.juju_model }}"


### PR DESCRIPTION
Add 2 Loki rules to alert on API failure detected in Landscape server based on [logs](https://documentation.ubuntu.com/landscape/reference/logs/logs/#server-logs). Smoke detector requirements:
- Warning alert when API failure rate >20% across all services over 1 hour
- Critical alert when API failure rate >70% across all services over 1 hour

<img width="1518" height="269" alt="Screenshot from 2026-01-28 14-59-08" src="https://github.com/user-attachments/assets/b3f246ad-7d76-4aec-a7bc-600409f75bf7" />


Expression check:
<img width="1839" height="856" alt="image" src="https://github.com/user-attachments/assets/7c9289f8-33ac-4911-a0de-c95c6aeb654f" />
