### PR TITLE
chore: update timing for some alerts

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -17,32 +17,32 @@ An overview of all alert rules.
 
 | Alert Name | Trigger Condition | Severity |
 |------------|-------------------|----------|
-| **CharmedOpenStackSubnetIPExhaustWarning** | Subnet IP usage >90% for 5 minutes | Warning |
-| **CharmedOpenStackSubnetIPExhausted** | All IPs in subnet exhausted for 5 minutes | Critical |
-| **CharmedOpenStackSubnetPoolExhaustWarning** | >90% of allocatable subnets (of a specific prefix length) used from subnet pool for 5 minutes | Warning |
-| **CharmedOpenStackSubnetPoolExhausted** | All allocatable subnets (of a specific prefix length) exhausted in subnet pool for 5 minutes | Critical |
-| **CharmedOpenStackNetworkQuotaWarning** | Network quota usage >90% for 5 minutes | Warning |
-| **CharmedOpenStackNetworkQuotaExhausted** | Network quota fully exhausted for 5 minutes | Critical |
-| **CharmedOpenStackPortQuotaWarning** | Port quota usage >90% for 5 minutes | Warning |
-| **CharmedOpenStackPortQuotaExhausted** | Port quota fully exhausted for 5 minutes | Critical |
-| **CharmedOpenStackRouterQuotaWarning** | Router quota usage >90% for 5 minutes | Warning |
-| **CharmedOpenStackRouterQuotaExhausted** | Router quota fully exhausted for 5 minutes | Critical |
-| **CharmedOpenStackFloatingIPQuotaWarning** | Floating IP quota usage >90% for 5 minutes | Warning |
-| **CharmedOpenStackFloatingIPQuotaExhausted** | Floating IP quota fully exhausted for 5 minutes | Critical |
-| **CharmedOpenStackSubnetQuotaWarning** | Subnet quota usage >90% for 5 minutes | Warning |
-| **CharmedOpenStackSubnetQuotaExhausted** | Subnet quota fully exhausted for 5 minutes | Critical |
-| **CharmedOpenStackSecurityGroupQuotaWarning** | Security group quota usage >90% for 5 minutes | Warning |
-| **CharmedOpenStackSecurityGroupQuotaExhausted** | Security group quota fully exhausted for 5 minutes | Critical |
+| **CharmedOpenStackSubnetIPExhaustWarning** | Subnet IP usage >90% for 10 minutes | Warning |
+| **CharmedOpenStackSubnetIPExhausted** | All IPs in subnet exhausted for 10 minutes | Critical |
+| **CharmedOpenStackSubnetPoolExhaustWarning** | >90% of allocatable subnets (of a specific prefix length) used from subnet pool for 10 minutes | Warning |
+| **CharmedOpenStackSubnetPoolExhausted** | All allocatable subnets (of a specific prefix length) exhausted in subnet pool for 10 minutes | Critical |
+| **CharmedOpenStackNetworkQuotaWarning** | Network quota usage >90% for 10 minutes | Warning |
+| **CharmedOpenStackNetworkQuotaExhausted** | Network quota fully exhausted for 10 minutes | Critical |
+| **CharmedOpenStackPortQuotaWarning** | Port quota usage >90% for 10 minutes | Warning |
+| **CharmedOpenStackPortQuotaExhausted** | Port quota fully exhausted for 10 minutes | Critical |
+| **CharmedOpenStackRouterQuotaWarning** | Router quota usage >90% for 10 minutes | Warning |
+| **CharmedOpenStackRouterQuotaExhausted** | Router quota fully exhausted for 10 minutes | Critical |
+| **CharmedOpenStackFloatingIPQuotaWarning** | Floating IP quota usage >90% for 10 minutes | Warning |
+| **CharmedOpenStackFloatingIPQuotaExhausted** | Floating IP quota fully exhausted for 10 minutes | Critical |
+| **CharmedOpenStackSubnetQuotaWarning** | Subnet quota usage >90% for 10 minutes | Warning |
+| **CharmedOpenStackSubnetQuotaExhausted** | Subnet quota fully exhausted for 10 minutes | Critical |
+| **CharmedOpenStackSecurityGroupQuotaWarning** | Security group quota usage >90% for 10 minutes | Warning |
+| **CharmedOpenStackSecurityGroupQuotaExhausted** | Security group quota fully exhausted for 10 minutes | Critical |
 
 ### Loki Alerts
 | Alert Name | Trigger Condition | Severity |
 |------------|-------------------|----------|
 | **CharmedOpenStackAPIFailureRateHigh** | API failure rate >20% across all services over 1 hour | Warning |
 | **CharmedOpenStackAPIFailureRateCritical** | API failure rate >70% across all services over 1 hour | Critical |
-| **CharmedOpenStackKeystoneAPIFailure** | Keystone API failure rate >10% over 5 minutes | Warning |
-| **CharmedOpenStackNovaAPIFailure** | Nova API failure rate >15% over 10 minutes | Warning |
-| **CharmedOpenStackNeutronAPIFailure** | Neutron API failure rate >15% over 10 minutes | Warning |
-| **CharmedOpenStackGlanceAPIFailure** | Glance API failure rate >15% over 10 minutes | Warning |
+| **CharmedOpenStackKeystoneAPIFailure** | Keystone API failure rate >20% over 10 minutes | Warning |
+| **CharmedOpenStackNovaAPIFailure** | Nova API failure rate >20% over 10 minutes | Warning |
+| **CharmedOpenStackNeutronAPIFailure** | Neutron API failure rate >20% over 10 minutes | Warning |
+| **CharmedOpenStackGlanceAPIFailure** | Glance API failure rate >20% over 10 minutes | Warning |
 | **CharmedOpenStackNewRoleAssignment** | New role assignment detected | Warning |
 | **CharmedOpenStackHighLoginFailureRate** | Authentication failure rate >20% over 1 hour | Warning |
 | **CharmedOpenStackMultipleFailedLoginsWarning** | User has ≥3 failed login attempts in 10 minutes | Warning |

--- a/rules/prod/loki/charmed_openstack_rules.rule
+++ b/rules/prod/loki/charmed_openstack_rules.rule
@@ -84,7 +84,7 @@ groups:
                     | pattern "<_> \"<_>\" status: <status_code_b> <_>"
                     | label_format status_code="{{if contains \"status:\" .status_code_a}}{{.status_code_b}}{{else}}{{.status_code_a}}{{end}}"
                     | status_code=~"(4|5).."
-                    [5m]
+                    [10m]
                   )
                 )
                 /
@@ -95,17 +95,17 @@ groups:
                     | pattern "<_> \"<_>\" status: <status_code_b> <_>"
                     | label_format status_code="{{if contains \"status:\" .status_code_a}}{{.status_code_b}}{{else}}{{.status_code_a}}{{end}}"
                     | status_code=~"(1|2|3|4|5).."
-                    [5m]
+                    [10m]
                   )
                 )
               ) * 100
-            ) > 10
+            ) > 20
           labels:
             alert_type: authentication_failure
             service: keystone
             severity: warning
           annotations:
-            description: Keystone service is experiencing {{ $value }}% failure rate over the last 5 minutes.
+            description: Keystone service is experiencing {{ $value }}% failure rate over the last 10 minutes.
             summary: Keystone API failures detected in Charmed OpenStack
 
         - alert: CharmedOpenStackNovaAPIFailure
@@ -134,7 +134,7 @@ groups:
                   )
                 )
               ) * 100
-            ) > 15
+            ) > 20
           labels:
             alert_type: compute_failure
             service: nova
@@ -169,7 +169,7 @@ groups:
                   )
                 )
               ) * 100
-            ) > 15
+            ) > 20
           labels:
             alert_type: network_failure
             service: neutron
@@ -204,7 +204,7 @@ groups:
                   )
                 )
               ) * 100
-            ) > 15
+            ) > 20
           labels:
             alert_type: image_failure
             service: glance

--- a/rules/prod/prometheus/charmed_openstack_rules.rule
+++ b/rules/prod/prometheus/charmed_openstack_rules.rule
@@ -5,7 +5,7 @@ groups:
       - alert: CharmedOpenStackSubnetIPExhaustWarning
         expr: |
           (openstack_neutron_network_ip_availabilities_used / openstack_neutron_network_ip_availabilities_total) * 100 > 90
-        for: 5m
+        for: 10m
         labels:
           alert_type: network_quota_exhaustion
           service: neutron
@@ -17,7 +17,7 @@ groups:
       - alert: CharmedOpenStackSubnetIPExhausted
         expr: |
           (openstack_neutron_network_ip_availabilities_total - openstack_neutron_network_ip_availabilities_used) <= 0
-        for: 5m
+        for: 10m
         labels:
           alert_type: network_quota_exhaustion
           severity: critical
@@ -30,7 +30,7 @@ groups:
       - alert: CharmedOpenStackSubnetPoolExhaustWarning
         expr: |
           (openstack_neutron_subnets_used / openstack_neutron_subnets_total) * 100 > 90
-        for: 5m
+        for: 10m
         labels:
           alert_type: network_quota_exhaustion
           severity: warning
@@ -42,7 +42,7 @@ groups:
       - alert: CharmedOpenStackSubnetPoolExhausted
         expr: |
           (openstack_neutron_subnets_free <= 0)
-        for: 5m
+        for: 10m
         labels:
           alert_type: network_quota_exhaustion
           severity: critical
@@ -55,7 +55,7 @@ groups:
       - alert: CharmedOpenStackNetworkQuotaWarning
         expr: |
           (openstack_neutron_networks / openstack_neutron_quota:networks:max) * 100 > 90
-        for: 5m
+        for: 10m
         labels:
           alert_type: network_quota_exhaustion
           service: neutron
@@ -67,7 +67,7 @@ groups:
       - alert: CharmedOpenStackNetworkQuotaExhausted
         expr: |
           (openstack_neutron_quota:networks:max - openstack_neutron_networks) <= 0
-        for: 5m
+        for: 10m
         labels:
           alert_type: network_quota_exhaustion
           service: neutron
@@ -79,7 +79,7 @@ groups:
       - alert: CharmedOpenStackPortQuotaWarning
         expr: |
           (openstack_neutron_ports / openstack_neutron_quota:ports:max) * 100 > 90
-        for: 5m
+        for: 10m
         labels:
           alert_type: network_quota_exhaustion
           service: neutron
@@ -91,7 +91,7 @@ groups:
       - alert: CharmedOpenStackPortQuotaExhausted
         expr: |
           (openstack_neutron_quota:ports:max - openstack_neutron_ports) <= 0
-        for: 5m
+        for: 10m
         labels:
           alert_type: network_quota_exhaustion
           service: neutron
@@ -103,7 +103,7 @@ groups:
       - alert: CharmedOpenStackRouterQuotaWarning
         expr: |
           (openstack_neutron_routers / openstack_neutron_quota:routers:max) * 100 > 90
-        for: 5m
+        for: 10m
         labels:
           alert_type: network_quota_exhaustion
           service: neutron
@@ -115,7 +115,7 @@ groups:
       - alert: CharmedOpenStackRouterQuotaExhausted
         expr: |
           (openstack_neutron_quota:routers:max - openstack_neutron_routers) <= 0
-        for: 5m
+        for: 10m
         labels:
           alert_type: network_quota_exhaustion
           service: neutron
@@ -127,7 +127,7 @@ groups:
       - alert: CharmedOpenStackFloatingIPQuotaWarning
         expr: |
           (openstack_neutron_floating_ips / openstack_neutron_quota:floating_ips:max) * 100 > 90
-        for: 5m
+        for: 10m
         labels:
           alert_type: network_quota_exhaustion
           service: neutron
@@ -139,7 +139,7 @@ groups:
       - alert: CharmedOpenStackFloatingIPQuotaExhausted
         expr: |
           (openstack_neutron_quota:floating_ips:max - openstack_neutron_floating_ips) <= 0
-        for: 5m
+        for: 10m
         labels:
           alert_type: network_quota_exhaustion
           service: neutron
@@ -151,7 +151,7 @@ groups:
       - alert: CharmedOpenStackSubnetQuotaWarning
         expr: |
           (openstack_neutron_subnets / openstack_neutron_quota:subnets:max) * 100 > 90
-        for: 5m
+        for: 10m
         labels:
           alert_type: network_quota_exhaustion
           service: neutron
@@ -163,7 +163,7 @@ groups:
       - alert: CharmedOpenStackSubnetQuotaExhausted
         expr: |
           (openstack_neutron_quota:subnets:max - openstack_neutron_subnets) <= 0
-        for: 5m
+        for: 10m
         labels:
           alert_type: network_quota_exhaustion
           service: neutron
@@ -175,7 +175,7 @@ groups:
       - alert: CharmedOpenStackSecurityGroupQuotaWarning
         expr: |
           (openstack_neutron_security_groups / openstack_neutron_quota:security_groups:max) * 100 > 90
-        for: 5m
+        for: 10m
         labels:
           alert_type: network_quota_exhaustion
           service: neutron
@@ -187,7 +187,7 @@ groups:
       - alert: CharmedOpenStackSecurityGroupQuotaExhausted
         expr: |
           (openstack_neutron_quota:security_groups:max - openstack_neutron_security_groups) <= 0
-        for: 5m
+        for: 10m
         labels:
           alert_type: network_quota_exhaustion
           service: neutron


### PR DESCRIPTION
For O7k network rules (Prometheus rules), update active duration from 5m to 10m.
For O7k API failure rules (Loki rules), update from  `>10% threshold, 5m time window` to `>20% threshold, 10m time window`