### PR TITLE
Add rules for o7k excessive api calls

### DIFF
--- a/docs/references.md
+++ b/docs/references.md
@@ -98,7 +98,7 @@ In `/var/log/apache2/keystone_access.log`:
 127.0.0.1 - - [27/Jan/2026:10:00:00 +0000] "GET /v3/auth/tokens HTTP/1.1" 200 1234 "-" "python-keystoneclient"
 127.0.0.1 - - [27/Jan/2026:10:00:01 +0000] "POST /v3/auth/tokens HTTP/1.1" 201 5678 "-" "python-keystoneclient"
 ```
-Alert will trigger if Keystone's 10-minute average exceeds 5000 requests/second.
+Alert will trigger if Keystone's 10-minute average exceeds 1000 requests/second.
 
 ### CharmedOpenStackNovaRequestHigh
 **Example log lines:**
@@ -108,7 +108,7 @@ In `/var/log/apache2/nova-api-os-compute_access.log`:
 127.0.0.1 - - [27/Jan/2026:10:00:00 +0000] "GET /v2.1/servers HTTP/1.1" 200 4321 "-" "python-novaclient"
 127.0.0.1 - - [27/Jan/2026:10:00:01 +0000] "POST /v2.1/servers HTTP/1.1" 202 8765 "-" "python-novaclient"
 ```
-Alert will trigger if Nova's 10-minute average exceeds 5000 requests/second.
+Alert will trigger if Nova's 10-minute average exceeds 1000 requests/second.
 
 ---
 

--- a/docs/references.md
+++ b/docs/references.md
@@ -80,6 +80,36 @@ In `/var/log/keystone/keystone.log`:
 ```
 Alert will trigger if there are many such lines with "outcome": "failure" from the same username in a period of time.
 
+### CharmedOpenStackAPIRequestBurst
+**Example log lines:**
+
+In `/var/log/apache2/keystone_access.log` or other OpenStack service logs:
+```
+127.0.0.1 - - [27/Jan/2026:10:00:00 +0000] "GET /v3/auth/tokens HTTP/1.1" 200 1234 "-" "python-keystoneclient"
+127.0.0.1 - - [27/Jan/2026:10:00:00 +0000] "POST /v3/auth/tokens HTTP/1.1" 201 5678 "-" "python-keystoneclient"
+```
+Alert will trigger if the 10-minute average request rate exceeds 3x the 1-hour baseline rate.
+
+### CharmedOpenStackKeystoneRequestHigh
+**Example log lines:**
+
+In `/var/log/apache2/keystone_access.log`:
+```
+127.0.0.1 - - [27/Jan/2026:10:00:00 +0000] "GET /v3/auth/tokens HTTP/1.1" 200 1234 "-" "python-keystoneclient"
+127.0.0.1 - - [27/Jan/2026:10:00:01 +0000] "POST /v3/auth/tokens HTTP/1.1" 201 5678 "-" "python-keystoneclient"
+```
+Alert will trigger if Keystone's 10-minute average exceeds 5000 requests/second.
+
+### CharmedOpenStackNovaRequestHigh
+**Example log lines:**
+
+In `/var/log/apache2/nova-api-os-compute_access.log`:
+```
+127.0.0.1 - - [27/Jan/2026:10:00:00 +0000] "GET /v2.1/servers HTTP/1.1" 200 4321 "-" "python-novaclient"
+127.0.0.1 - - [27/Jan/2026:10:00:01 +0000] "POST /v2.1/servers HTTP/1.1" 202 8765 "-" "python-novaclient"
+```
+Alert will trigger if Nova's 10-minute average exceeds 5000 requests/second.
+
 ---
 
 ## Canonical K8s

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -47,6 +47,9 @@ An overview of all alert rules.
 | **CharmedOpenStackHighLoginFailureRate** | Authentication failure rate >20% over 1 hour | Warning |
 | **CharmedOpenStackMultipleFailedLoginsWarning** | User has ≥3 failed login attempts in 10 minutes | Warning |
 | **CharmedOpenStackMultipleFailedLoginsCritical** | User has ≥5 failed login attempts in 10 minutes | Critical |
+| **CharmedOpenStackAPIRequestBurst** | 10-minute API request rate exceeds 3x the 1-hour baseline | Warning |
+| **CharmedOpenStackKeystoneRequestHigh** | Keystone receiving >1000 requests/second over 10 minutes | Warning |
+| **CharmedOpenStackNovaRequestHigh** | Nova receiving >1000 requests/second over 10 minutes | Warning |
 
 ## Canonical K8s Alert Rules
 

--- a/rules/prod/loki/charmed_openstack_rules.rule
+++ b/rules/prod/loki/charmed_openstack_rules.rule
@@ -6,7 +6,7 @@ groups:
           expr: |-
             (
               (
-                sum by (filename)(
+                sum by (juju_model, filename)(
                   rate(
                     {filename=~"/var/log/(nova|ovn|keystone|cinder|glance|neutron|openvswitch|ceph|apache2)/.*"}
                     | pattern "<_> \"<_>\" <status_code_a> <_>"
@@ -17,7 +17,7 @@ groups:
                   )
                 )
                 /
-                sum by (filename)(
+                sum by (juju_model, filename)(
                   rate(
                     {filename=~"/var/log/(nova|ovn|keystone|cinder|glance|neutron|openvswitch|ceph|apache2)/.*"}
                     | pattern "<_> \"<_>\" <status_code_a> <_>"
@@ -40,7 +40,7 @@ groups:
           expr: |-
             (
               (
-                sum by (filename)(
+                sum by (juju_model, filename)(
                   rate(
                     {filename=~"/var/log/(nova|keystone|cinder|glance|neutron|openvswitch|ceph|apache2)/.*"}
                     | pattern "<_> \"<_>\" <status_code_a> <_>"
@@ -51,7 +51,7 @@ groups:
                   )
                 )
                 /
-                sum by (filename)(
+                sum by (juju_model, filename)(
                   rate(
                     {filename=~"/var/log/(nova|keystone|cinder|glance|neutron|openvswitch|ceph|apache2)/.*"}
                     | pattern "<_> \"<_>\" <status_code_a> <_>"
@@ -77,7 +77,7 @@ groups:
           expr: |-
             (
               (
-                sum(
+                sum by (juju_model)(
                   rate(
                     {filename=~"/var/log/(keystone|apache2)/(keystone*).*"}
                     | pattern "<_> \"<_>\" <status_code_a> <_>"
@@ -88,7 +88,7 @@ groups:
                   )
                 )
                 /
-                sum(
+                sum by (juju_model)(
                   rate(
                     {filename=~"/var/log/(keystone|apache2)/(keystone*).*"}
                     | pattern "<_> \"<_>\" <status_code_a> <_>"
@@ -112,7 +112,7 @@ groups:
           expr: |-
             (
               (
-                sum(
+                sum by (juju_model)(
                   rate(
                     {filename=~"/var/log/(nova|apache2)/(nova*).*"}
                     | pattern "<_> \"<_>\" <status_code_a> <_>"
@@ -123,7 +123,7 @@ groups:
                   )
                 )
                 /
-                sum(
+                sum by (juju_model)(
                   rate(
                     {filename=~"/var/log/(nova|apache2)/(nova*).*"}
                     | pattern "<_> \"<_>\" <status_code_a> <_>"
@@ -147,7 +147,7 @@ groups:
           expr: |-
             (
               (
-                sum(
+                sum by (juju_model)(
                   rate(
                     {filename=~"/var/log/neutron/.*"}
                     | pattern "<_> \"<_>\" <status_code_a> <_>"
@@ -158,7 +158,7 @@ groups:
                   )
                 )
                 /
-                sum(
+                sum by (juju_model)(
                   rate(
                     {filename=~"/var/log/neutron/.*"}
                     | pattern "<_> \"<_>\" <status_code_a> <_>"
@@ -182,7 +182,7 @@ groups:
           expr: |-
             (
               (
-                sum(
+                sum by (juju_model)(
                   rate(
                     {filename=~"/var/log/glance/.*"}
                     | pattern "<_> \"<_>\" <status_code_a> <_>"
@@ -193,7 +193,7 @@ groups:
                   )
                 )
                 /
-                sum(
+                sum by (juju_model)(
                   rate(
                     {filename=~"/var/log/glance/.*"}
                     | pattern "<_> \"<_>\" <status_code_a> <_>"
@@ -219,7 +219,7 @@ groups:
         - alert: CharmedOpenstackNewRoleAssignment
           expr: |-
             (
-              count(
+              count by (juju_model)(
                 rate(
                   {filename=~"/var/log/keystone/.*.log"}
                   |= "event_type"
@@ -243,7 +243,7 @@ groups:
           expr: |-
             (
               (
-                count(
+                count by (juju_model)(
                   rate(
                     {filename=~"/var/log/keystone/.*.log"}
                     |= "event_type"
@@ -256,7 +256,7 @@ groups:
                   )
                 )
                 /
-                count(
+                count by (juju_model)(
                   rate(
                     {filename=~"/var/log/keystone/.*.log"}
                     |= "event_type"
@@ -280,7 +280,7 @@ groups:
 
         - alert: CharmedOpenStackMultipleFailedLoginsWarning
           expr: |-
-            sum by (initiator_name) (
+            sum by (juju_model, initiator_name) (
               count_over_time(
                 {filename=~"/var/log/keystone/.*.log"}
                 |= "event_type"
@@ -303,7 +303,7 @@ groups:
 
         - alert: CharmedOpenStackMultipleFailedLoginsCritical
           expr: |-
-            sum by (initiator_name) (
+            sum by (juju_model, initiator_name) (
               count_over_time(
                 {filename=~"/var/log/keystone/.*.log"}
                 |= "event_type"
@@ -324,3 +324,70 @@ groups:
             description: User {{ $labels.initiator_name }} has {{ $value }} failed login attempts in the last 10 minutes.
             summary: Multiple failed login attempts detected for user in Charmed OpenStack
 
+    - name: charmed-openstack-excessive-requests
+      rules:
+        - alert: CharmedOpenStackAPIRequestBurst
+          expr: |-
+            (
+              sum by (juju_model) (
+                rate(
+                  {filename=~"/var/log/(nova|keystone|cinder|glance|neutron|apache2)/.*"}
+                  | pattern `<_> "<method> <_>" <status_code> <_>`
+                  | status_code=~"[1-5].."
+                  [10m]
+                )
+              )
+              >
+              3 * (
+                sum by (juju_model) (
+                  rate(
+                    {filename=~"/var/log/(nova|keystone|cinder|glance|neutron|apache2)/.*"}
+                    | pattern `<_> "<method> <_>" <status_code> <_>`
+                    | status_code=~"[1-5].."
+                    [1h]
+                  )
+                )
+              )
+            )
+          labels:
+            alert_type: api_abuse
+            severity: warning
+          annotations:
+            description: "API request rate in {{ $labels.juju_model }} is {{ $value }} requests/second over the last 10 minutes, exceeding 3x the 1-hour baseline."
+            summary: Sudden burst of API requests detected in Charmed OpenStack
+
+        - alert: CharmedOpenStackKeystoneRequestHigh
+          expr: |-
+            sum by (juju_model) (
+              rate(
+                {filename=~"/var/log/(keystone|apache2)/keystone.*"}
+                | pattern `<_> "<method> <_>" <status_code> <_>`
+                | status_code=~"[1-5].."
+                [10m]
+              )
+            ) > 1000
+          labels:
+            alert_type: api_abuse
+            service: keystone
+            severity: warning
+          annotations:
+            description: "Keystone service is receiving {{ $value }} requests/second over the last 10 minutes."
+            summary: Keystone API request flood in Charmed OpenStack
+
+        - alert: CharmedOpenStackNovaRequestHigh
+          expr: |-
+            sum by (juju_model) (
+              rate(
+                {filename=~"/var/log/(nova|apache2)/nova.*"}
+                | pattern `<_> "<method> <_>" <status_code> <_>`
+                | status_code=~"[1-5].."
+                [10m]
+              )
+            ) > 1000
+          labels:
+            alert_type: api_abuse
+            service: nova
+            severity: warning
+          annotations:
+            description: "Nova compute service is receiving {{ $value }} requests/second over the last 10 minutes."
+            summary: Nova API request flood in Charmed OpenStack


### PR DESCRIPTION
This PR adds 3 rules for detecting possible excessive API calls in charmed O7k:

- Warning when total requests/s in the last 10m is higher than 3x of last 1h. Example (test with 1.1x threshold):
   <img width="1452" height="817" alt="image" src="https://github.com/user-attachments/assets/d2ad58f6-320f-4865-85b8-4a370d5776e5" />

- Warning when requests/s in the last 10m for Keystone > 1000req/s. Example (test with 10 req/s threshold):
  <img width="1479" height="746" alt="image" src="https://github.com/user-attachments/assets/66be532e-2575-486b-bdec-965ec4c7a422" />

- Warning when requests/s in the last 10m for Nova > 1000req/s. Example (test with 10 req/s threshold):
  <img width="1479" height="746" alt="image" src="https://github.com/user-attachments/assets/34aca589-56b6-4663-a882-dfdc6c88a4d9" />

The thresholds need confirmation to match the traffic situation of prod site - or match the rate limiting (if set) either from the LB of each service API, or from a centralized external LB for all O7k APIs. Critical alerts can be added after having more information. 

Also update existing rules with aggregating by `juju_model` in case COS is monitoring multiple O7k clusters.
