### PR TITLE
Add rules for k8s excessive api calls

### DIFF
--- a/docs/references.md
+++ b/docs/references.md
@@ -154,4 +154,26 @@ In `/var/log/kubernetes/audit.log`:
 
 Alert will trigger if a user has multiple access failures (401 or 403) in a short period of time.
 
+### Excessive Request Detection Alerts
+
+#### CanonicalK8sAPIRequestBurst
+**Example log pattern:**
+
+In `/var/log/kubernetes/audit.log`:
+```json
+{"kind":"Event","apiVersion":"audit.k8s.io/v1","level":"Metadata","auditID":"abc123","stage":"ResponseComplete","requestURI":"/api/v1/namespaces/default/pods","verb":"list","user":{"username":"system:serviceaccount:default:my-app","groups":["system:serviceaccounts","system:authenticated"]},"sourceIPs":["10.0.0.50"],"userAgent":"my-app/v1.0","objectRef":{"resource":"pods","namespace":"default","apiVersion":"v1"},"responseStatus":{"metadata":{},"code":200},"requestReceivedTimestamp":"2026-01-27T10:00:00.000000Z","stageTimestamp":"2026-01-27T10:00:00.010000Z"}
+```
+
+Alert will trigger when the API request rate over 10 minutes exceeds 3x the 1-hour baseline, indicating possible DDoS, misconfigured automation, or retry storm.
+
+#### CanonicalK8sHighRequestRatePerUser
+**Example log pattern:**
+
+In `/var/log/kubernetes/audit.log`:
+```json
+{"kind":"Event","apiVersion":"audit.k8s.io/v1","level":"Metadata","auditID":"def456","stage":"ResponseComplete","requestURI":"/api/v1/namespaces/default/configmaps","verb":"get","user":{"username":"system:serviceaccount:monitoring:prometheus","groups":["system:serviceaccounts","system:authenticated"]},"sourceIPs":["10.0.0.100"],"userAgent":"Prometheus/2.45.0","objectRef":{"resource":"configmaps","namespace":"default","apiVersion":"v1"},"responseStatus":{"metadata":{},"code":200},"requestReceivedTimestamp":"2026-01-27T10:00:01.000000Z","stageTimestamp":"2026-01-27T10:00:01.005000Z"}
+```
+
+Alert will trigger when a single user exceeds 50 requests/second sustained over 10 minutes, indicating possible compromised service account or runaway application.
+
 ---

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -90,3 +90,5 @@ An overview of all alert rules.
 | **CanonicalK8sDaemonSetDeleted** | DaemonSet deleted in past 3 days | Warning |
 | **CanonicalK8sUserAccessFailuresWarning** | User has ≥3 access failures in 10 minutes | Warning |
 | **CanonicalK8sUserAccessFailuresCritical** | User has ≥5 access failures in 10 minutes | Critical |
+| **CanonicalK8sAPIRequestBurst** | API request rate over 10 minutes exceeds 3x the 1-hour baseline | Warning |
+| **CanonicalK8sHighRequestRatePerUser** | User exceeds 50 requests/second over 10 minutes | Warning |

--- a/rules/prod/loki/canonical_k8s_rules.rule
+++ b/rules/prod/loki/canonical_k8s_rules.rule
@@ -4,7 +4,7 @@ groups:
       rules:
         - alert: CanonicalK8sRoleCreated
           expr: |-
-            count(
+            count by (juju_model) (
               rate(
                 {filename=~"/var/log/kubernetes/audit.log.*"}
                 | json
@@ -23,7 +23,7 @@ groups:
 
         - alert: CanonicalK8sRoleUpdated
           expr: |-
-            count(
+            count by (juju_model) (
               rate(
                 {filename=~"/var/log/kubernetes/audit.log.*"}
                 | json
@@ -42,7 +42,7 @@ groups:
 
         - alert: CanonicalK8sRoleDeleted
           expr: |-
-            count(
+            count by (juju_model) (
               rate(
                 {filename=~"/var/log/kubernetes/audit.log.*"}
                 | json
@@ -61,7 +61,7 @@ groups:
 
         - alert: CanonicalK8sClusterRoleCreated
           expr: |-
-            count(
+            count by (juju_model) (
               rate(
                 {filename=~"/var/log/kubernetes/audit.log.*"}
                 | json
@@ -80,7 +80,7 @@ groups:
 
         - alert: CanonicalK8sClusterRoleUpdated
           expr: |-
-            count(
+            count by (juju_model) (
               rate(
                 {filename=~"/var/log/kubernetes/audit.log.*"}
                 | json
@@ -99,7 +99,7 @@ groups:
 
         - alert: CanonicalK8sClusterRoleDeleted
           expr: |-
-            count(
+            count by (juju_model) (
               rate(
                 {filename=~"/var/log/kubernetes/audit.log.*"}
                 | json
@@ -118,7 +118,7 @@ groups:
 
         - alert: CanonicalK8sRoleBindingCreated
           expr: |-
-            count(
+            count by (juju_model) (
               rate(
                 {filename=~"/var/log/kubernetes/audit.log.*"}
                 | json
@@ -137,7 +137,7 @@ groups:
 
         - alert: CanonicalK8sRoleBindingUpdated
           expr: |-
-            count(
+            count by (juju_model) (
               rate(
                 {filename=~"/var/log/kubernetes/audit.log.*"}
                 | json
@@ -156,7 +156,7 @@ groups:
 
         - alert: CanonicalK8sRoleBindingDeleted
           expr: |-
-            count(
+            count by (juju_model) (
               rate(
                 {filename=~"/var/log/kubernetes/audit.log.*"}
                 | json
@@ -175,7 +175,7 @@ groups:
 
         - alert: CanonicalK8sClusterRoleBindingCreated
           expr: |-
-            count(
+            count by (juju_model) (
               rate(
                 {filename=~"/var/log/kubernetes/audit.log.*"}
                 | json
@@ -194,7 +194,7 @@ groups:
 
         - alert: CanonicalK8sClusterRoleBindingUpdated
           expr: |-
-            count(
+            count by (juju_model) (
               rate(
                 {filename=~"/var/log/kubernetes/audit.log.*"}
                 | json
@@ -213,7 +213,7 @@ groups:
 
         - alert: CanonicalK8sClusterRoleBindingDeleted
           expr: |-
-            count(
+            count by (juju_model) (
               rate(
                 {filename=~"/var/log/kubernetes/audit.log.*"}
                 | json
@@ -232,7 +232,7 @@ groups:
 
         - alert: CanonicalK8sServiceAccountCreated
           expr: |-
-            count(
+            count by (juju_model) (
               rate(
                 {filename=~"/var/log/kubernetes/audit.log.*"}
                 | json
@@ -251,7 +251,7 @@ groups:
 
         - alert: CanonicalK8sServiceAccountUpdated
           expr: |-
-            count(
+            count by (juju_model) (
               rate(
                 {filename=~"/var/log/kubernetes/audit.log.*"}
                 | json
@@ -270,7 +270,7 @@ groups:
 
         - alert: CanonicalK8sServiceAccountDeleted
           expr: |-
-            count(
+            count by (juju_model) (
               rate(
                 {filename=~"/var/log/kubernetes/audit.log.*"}
                 | json
@@ -289,7 +289,7 @@ groups:
 
         - alert: CanonicalK8sSecretCreated
           expr: |-
-            count(
+            count by (juju_model) (
               rate(
                 {filename=~"/var/log/kubernetes/audit.log.*"}
                 | json
@@ -308,7 +308,7 @@ groups:
 
         - alert: CanonicalK8sSecretUpdated
           expr: |-
-            count(
+            count by (juju_model) (
               rate(
                 {filename=~"/var/log/kubernetes/audit.log.*"}
                 | json
@@ -327,7 +327,7 @@ groups:
 
         - alert: CanonicalK8sSecretDeleted
           expr: |-
-            count(
+            count by (juju_model) (
               rate(
                 {filename=~"/var/log/kubernetes/audit.log.*"}
                 | json
@@ -346,7 +346,7 @@ groups:
 
         - alert: CanonicalK8sDaemonSetCreated
           expr: |-
-            count(
+            count by (juju_model) (
               rate(
                 {filename=~"/var/log/kubernetes/audit.log.*"}
                 | json
@@ -365,7 +365,7 @@ groups:
 
         - alert: CanonicalK8sDaemonSetUpdated
           expr: |-
-            count(
+            count by (juju_model) (
               rate(
                 {filename=~"/var/log/kubernetes/audit.log.*"}
                 | json
@@ -384,7 +384,7 @@ groups:
 
         - alert: CanonicalK8sDaemonSetDeleted
           expr: |-
-            count(
+            count by (juju_model) (
               rate(
                 {filename=~"/var/log/kubernetes/audit.log.*"}
                 | json
@@ -406,7 +406,7 @@ groups:
       rules:
         - alert: CanonicalK8sUserAccessFailuresWarning
           expr: |-
-            sum by (user_username) (
+            sum by (juju_model, user_username) (
               count_over_time(
                 {filename=~"/var/log/kubernetes/audit.log.*"}
                 | json
@@ -424,7 +424,7 @@ groups:
 
         - alert: CanonicalK8sUserAccessFailuresCritical
           expr: |-
-            sum by (user_username) (
+            sum by (juju_model, user_username) (
               count_over_time(
                 {filename=~"/var/log/kubernetes/audit.log.*"}
                 | json
@@ -439,3 +439,50 @@ groups:
           annotations:
             description: User {{ $labels.user_username }} had {{ $value }} access failures (401/403) in the last 10 minutes. Possible brute-force attack or privilege escalation attempt detected.
             summary: Excessive access failures detected for user in Canonical K8s
+
+    - name: canonical-k8s-excessive-requests
+      rules:
+        - alert: CanonicalK8sAPIRequestBurst
+          expr: |-
+            (
+              sum by (juju_model) (
+                rate(
+                  {filename=~"/var/log/kubernetes/audit.log.*"}
+                  | json
+                  [10m]
+                )
+              )
+              >
+              3 * (
+                sum by (juju_model) (
+                  rate(
+                    {filename=~"/var/log/kubernetes/audit.log.*"}
+                    | json
+                    [1h]
+                  )
+                )
+              )
+            )
+          labels:
+            alert_type: api_abuse
+            severity: warning
+          annotations:
+            description: "API request rate in {{ $labels.juju_model }} is {{ $value }} requests/second over the last 10 minutes, exceeding 3x the 1-hour baseline."
+            summary: Sudden burst of API requests detected in Canonical K8s
+
+        - alert: CanonicalK8sHighRequestRatePerUser
+          expr: |-
+            sum by (juju_model, user_username) (
+              rate(
+                {filename=~"/var/log/kubernetes/audit.log.*"}
+                | json
+                | user_username != ""
+                [10m]
+              )
+            ) > 50
+          labels:
+            alert_type: api_abuse
+            severity: warning
+          annotations:
+            description: "User {{ $labels.user_username }} has made {{ $value }} requests/second in the last 10 minutes."
+            summary: High API request rate from single user in Canonical K8s

--- a/rules/prod/loki/canonical_k8s_rules.rule
+++ b/rules/prod/loki/canonical_k8s_rules.rule
@@ -467,7 +467,7 @@ groups:
             alert_type: api_abuse
             severity: warning
           annotations:
-            description: "API request rate in {{ $labels.juju_model }} is {{ $value }} requests/second over the last 10 minutes, exceeding 3x the 1-hour baseline."
+            description: "API request rate in {{ $labels.juju_model }} is {{ $value }} requests/second over the last 10 minutes, exceeding 3x the 1-hour baseline. Possible DDoS attack, misconfigured automation, or retry storm detected."
             summary: Sudden burst of API requests detected in Canonical K8s
 
         - alert: CanonicalK8sHighRequestRatePerUser
@@ -484,5 +484,5 @@ groups:
             alert_type: api_abuse
             severity: warning
           annotations:
-            description: "User {{ $labels.user_username }} has made {{ $value }} requests/second in the last 10 minutes."
+            description: "User {{ $labels.user_username }} has made {{ $value }} requests/second in the last 10 minutes. Possible compromised service account, runaway application, or abusive client behavior."
             summary: High API request rate from single user in Canonical K8s


### PR DESCRIPTION
This PR adds 2 rules for detecting possible excessive API calls in charmed Canonical K8s:

- Warning when total requests/s in the last 10m is higher than 3x of last 1h. Example (test with 1.1x threshold):
  
   <img width="1489" height="815" alt="k8sburst" src="https://github.com/user-attachments/assets/50793067-ce37-430a-8892-27fc677bc24b" />

- Warning when requests/s in the last 10m from a user > 50req/s. Example (test with 5 req/s threshold):
  
   <img width="1474" height="760" alt="k8shighperuser" src="https://github.com/user-attachments/assets/dda729da-b5eb-477b-8ac3-fcb92c804128" />

The thresholds need confirmation to match the traffic situation of prod site, and should match how rate limiting or [APF](https://kubernetes.io/docs/concepts/cluster-administration/flow-control/) is setup in the actual api-server. Critical alerts and APF related alerts can be added after having more information.

Also update existing rules with aggregating by `juju_model` in case COS is monitoring multiple K8s clusters.