### PR TITLE
Add Loki rules for charmed Opensearch audit events

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Contains "smoke-alarm" rules for these use cases:
 - charmed openstack
 - landscape server
 - charmed kubeflow
+- charmed opensearch
 
 This repository should be referenced by the [cos-configuration-k8s](https://charmhub.io/cos-configuration-k8s) charm to forward alert rules to Canonical Observability Stack (COS).
 
@@ -16,5 +17,6 @@ See audit logging and other setup guides for each use case:
 - [Canonical K8s](docs/setup_guides/canonical_k8s_setup.md)
 - [Landscape Server](docs/setup_guides/landscape_server_references.md)
 - [Charmed Kubeflow](docs/setup_guides/charmed_kubeflow_setup.md)
+- [Charmed OpenSearch](docs/setup_guides/charmed_opensearch_setup.md)
 
 See all alert rules and example log references in [rules.md](docs/rules.md) and [references.md](docs/references.md).

--- a/docs/references.md
+++ b/docs/references.md
@@ -265,3 +265,46 @@ In `istio-ingressgateway` access logs (via Promtail with `charm="istio-gateway"`
 Alert will trigger if the proportion of requests with 4xx or 5xx status codes exceeds the threshold over 1 hour.
 
 ---
+
+## Charmed OpenSearch
+
+These log lines contain audit events from the OpenSearch Security plugin. Logs are embedded as JSON within the `message` field of server logs.
+
+### CharmedOpenSearchSecurityAuditEvents*
+
+**Example log lines:**
+
+In `/var/snap/opensearch/common/var/log/opensearch/*_server.json` (collected via OpenTelemetry Collector at `/snap/opentelemetry-collector/.*/shared-logs/opensearch/*.json`):
+
+**Failed Login:**
+```json
+{
+  "type": "server",
+  "timestamp": "2026-01-29T00:42:17,757Z",
+  "level": "INFO",
+  "component": "audit",
+  "cluster.name": "opensearch-93fo",
+  "node.name": "opensearch-1.8be",
+  "message": "{\"audit_category\":\"FAILED_LOGIN\",\"audit_rest_request_path\":\"/\",\"audit_request_remote_address\":\"10.121.59.1\",\"audit_request_effective_user\":\"username\",\"@timestamp\":\"2026-01-29T00:42:17.757+00:00\"}",
+  "cluster.uuid": "sw8DD38gSoKSZhRpULtg3w",
+  "node.id": "ePAT6T0NRdOrqsZN--9w3Q"
+}
+```
+
+**Missing Privileges:**
+```json
+{
+  "type": "server",
+  "timestamp": "2026-01-29T00:42:20,982Z",
+  "level": "INFO",
+  "component": "audit",
+  "cluster.name": "opensearch-93fo",
+  "node.name": "opensearch-1.8be",
+  "message": "{\"audit_category\":\"MISSING_PRIVILEGES\",\"audit_request_privilege\":\"indices:admin/delete\",\"audit_request_effective_user\":\"admin\",\"audit_trace_resolved_indices\":[\".plugins-ml-config\",\"test-index\"],\"@timestamp\":\"2026-01-29T00:42:20.981+00:00\"}",
+  "cluster.uuid": "sw8DD38gSoKSZhRpULtg3w",
+  "node.id": "ePAT6T0NRdOrqsZN--9w3Q"
+}
+```
+Alert will trigger if >3 security audit events (FAILED_LOGIN, MISSING_PRIVILEGES, BAD_HEADERS, SSL_EXCEPTION, opensearch_SECURITY_INDEX_ATTEMPT) occur in 10 minutes.
+
+---

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -116,3 +116,12 @@ An overview of all alert rules.
 |------------|-------------------|----------|
 | **KubeflowGatewayFailureRateHigh** | User-facing API failure rate (4xx/5xx) >20% over 1 hour | Warning |
 | **KubeflowGatewayFailureRateCritical** | User-facing API failure rate (4xx/5xx) >70% over 1 hour | Critical |
+
+## Charmed OpenSearch Alert Rules
+
+### Loki Alerts
+
+| Alert Name | Trigger Condition | Severity |
+|------------|-------------------|----------|
+| **CharmedOpenSearchSecurityAuditEventsHigh** | >3 security audit events in 10 minutes | Warning |
+| **CharmedOpenSearchSecurityAuditEventsCritical** | >5 security audit events in 10 minutes | Critical |

--- a/docs/setup_guides/charmed_opensearch_setup.md
+++ b/docs/setup_guides/charmed_opensearch_setup.md
@@ -1,0 +1,121 @@
+# Charmed OpenSearch Audit Logging Setup
+
+This guide covers sample setup of audit logging for a Charmed OpenSearch deployment integrated with Canonical Observability Stack (COS).
+
+## Overview
+
+Charmed OpenSearch supports audit logging through the OpenSearch Security plugin. This enables security monitoring by capturing authentication attempts, authorization failures, and other security events.
+
+## Prerequisites
+
+- [Charmed OpenSearch](https://canonical-charmed-opensearch.readthedocs-hosted.com/2/) deployment
+- [COS](https://documentation.ubuntu.com/observability/latest/) deployment
+
+## Setup Steps
+
+### 1. Deploy and Configure OpenTelemetry Collector
+
+Deploy OpenTelemetry Collector as a subordinate charm to OpenSearch units:
+
+> **Note:** This guide uses `opentelemetry-collector` because at the time of this writing, `grafana-agent` is EOL. The [rules](../../rules/prod/loki/charmed_opensearch_rules.rule) are catered for OpenTelemetry Collector and will not work with `grafana-agent`.
+
+```bash
+# Deploy opentelemetry-collector as subordinate
+juju deploy opentelemetry-collector --base ubuntu@<match-opensearch-charm-base>
+
+# Relate to OpenSearch to opentelemetry-collector
+juju relate opentelemetry-collector opensearch
+
+# Connect to COS Loki (assumes offer exists)
+juju relate opentelemetry-collector loki-logging
+```
+
+### 2. Enable Audit Logging
+
+Configure OpenSearch to write audit logs to files (`log4j` backend):
+
+```bash
+juju exec --app opensearch -- sudo sh -c '
+  KEY="plugins.security.audit.type"
+  VALUE="log4j"
+  FILE="/var/snap/opensearch/current/etc/opensearch/opensearch.yml"
+
+  if grep -qE "^${KEY}: ${VALUE}$" "$FILE"; then
+    echo "Already configured"
+  elif grep -qE "^${KEY}:" "$FILE"; then
+    sed -i -E "s|^${KEY}:.*|${KEY}: ${VALUE}|" "$FILE"
+    echo "Updated existing line"
+  else
+    echo "${KEY}: ${VALUE}" >> "$FILE"
+    echo "Added new line"
+  fi
+  grep "^${KEY}:" "$FILE"
+'
+```
+
+### 3. Restart OpenSearch
+
+Apply the configuration changes by restarting OpenSearch:
+
+```bash
+juju exec --app opensearch -- sudo systemctl restart snap.opensearch.daemon
+```
+
+### 4. Configure COS Alert Rules
+
+Switch to your COS model and deploy [cos-configuration-k8s](https://charmhub.io/cos-configuration-k8s):
+
+```bash
+# Switch to COS model
+juju switch cos
+
+# Deploy cos-configuration-k8s charm
+juju deploy cos-configuration-k8s cos-config \
+    --config git_repo=https://github.com/my-repo/cos-config \
+    --config git_branch=main \
+    --config git_depth=1 \
+    --config loki_alert_rules_path=rules/prod/loki/
+
+# Relate to Loki
+juju relate loki cos-config
+```
+
+## Log Sources
+
+Audit logs are collected from OpenTelemetry Collector's shared logs mount:
+
+```
+/snap/opentelemetry-collector/.*/shared-logs/opensearch/*.json
+```
+
+These map to OpenSearch's actual log location:
+```
+/var/snap/opensearch/common/var/log/opensearch/*_server.json
+```
+
+## Audit Log Format
+
+Audit logs are embedded as JSON within the `message` field of server logs:
+
+```json
+{
+  "type": "server",
+  "timestamp": "2026-01-29T00:42:14,120Z",
+  "level": "INFO",
+  "component": "audit",
+  "cluster.name": "opensearch-93fo",
+  "node.name": "opensearch-1.8be",
+  "message": "{\"audit_cluster_name\":\"opensearch-93fo\",\"audit_node_name\":\"opensearch-1.8be\",\"audit_rest_request_method\":\"GET\",\"audit_category\":\"FAILED_LOGIN\",\"audit_request_origin\":\"REST\",\"audit_node_id\":\"ePAT6T0NRdOrqsZN--9w3Q\",\"audit_request_layer\":\"REST\",\"audit_rest_request_path\":\"/\",\"@timestamp\":\"2026-01-29T00:42:14.119+00:00\",\"audit_request_effective_user_is_admin\":false,\"audit_format_version\":4,\"audit_request_remote_address\":\"10.121.59.1\",\"audit_node_host_address\":\"10.121.59.133\",\"audit_rest_request_headers\":{\"User-Agent\":[\"curl/8.5.0\"],\"Host\":[\"10.121.59.133:9200\"],\"Accept\":[\"*/*\"]},\"audit_request_effective_user\":\"opensearch-client_5\",\"audit_node_host_name\":\"10.121.59.133\"}", "cluster.uuid": "sw8DD38gSoKSZhRpULtg3w", "node.id": "ePAT6T0NRdOrqsZN--9w3Q"
+}
+```
+
+## Additional Notes
+
+- Events with `audit_category` of `AUTHENTICATED` and `GRANTED_PRIVILEGES` are excluded from alerting to reduce noise from normal operations.
+
+## References
+
+- [OpenSearch Audit Logs Documentation](https://docs.opensearch.org/latest/security/audit-logs/index/)
+- [OpenSearch Audit Log Storage Types](https://docs.opensearch.org/latest/security/audit-logs/storage-types/)
+- [Charmed OpenSearch Documentation](https://canonical-charmed-opensearch.readthedocs-hosted.com/2/)
+- [OpenTelemetry Collector Charm](https://charmhub.io/opentelemetry-collector)

--- a/docs/setup_guides/charmed_opensearch_setup.md
+++ b/docs/setup_guides/charmed_opensearch_setup.md
@@ -23,8 +23,8 @@ Deploy OpenTelemetry Collector as a subordinate charm to OpenSearch units:
 # Deploy opentelemetry-collector as subordinate
 juju deploy opentelemetry-collector --base ubuntu@<match-opensearch-charm-base>
 
-# Relate to OpenSearch to opentelemetry-collector
-juju relate opentelemetry-collector opensearch
+# Relate OpenSearch to opentelemetry-collector
+juju relate opensearch opentelemetry-collector
 
 # Connect to COS Loki (assumes offer exists)
 juju relate opentelemetry-collector loki-logging

--- a/rules/prod/loki/charmed_opensearch_rules.rule
+++ b/rules/prod/loki/charmed_opensearch_rules.rule
@@ -1,0 +1,49 @@
+namespace: charmed_opensearch_rules
+groups:
+  - name: charmed-opensearch-audit-events
+    rules:
+      - alert: CharmedOpenSearchSecurityAuditEventsHigh
+        expr: |-
+          sum by (juju_model, audit_category) (
+            count_over_time(
+              {filename=~"/snap/opentelemetry-collector/.*/shared-logs/opensearch/.*\\.json"}
+              | json
+              | component="audit"
+              | line_format "{{.message}}"
+              | json
+              | audit_category=~"FAILED_LOGIN|MISSING_PRIVILEGES|BAD_HEADERS|SSL_EXCEPTION|opensearch_SECURITY_INDEX_ATTEMPT"
+              [10m]
+            )
+          ) > 3
+        labels:
+          alert_type: security_event
+          service: opensearch
+          severity: warning
+        annotations:
+          description: |
+            OpenSearch in {{ $labels.juju_model }} has {{ $value }} security events {{ $labels.audit_category }} in the last 10 minutes.
+            This may indicate authentication failures, unauthorized access attempts, or security misconfigurations.
+          summary: "High security audit events (>3) in OpenSearch"
+
+      - alert: CharmedOpenSearchSecurityAuditEventsCritical
+        expr: |-
+          sum by (juju_model, audit_category) (
+            count_over_time(
+              {filename=~"/snap/opentelemetry-collector/.*/shared-logs/opensearch/.*\\.json"}
+              | json
+              | component="audit"
+              | line_format "{{.message}}"
+              | json
+              | audit_category=~"FAILED_LOGIN|MISSING_PRIVILEGES|BAD_HEADERS|SSL_EXCEPTION|opensearch_SECURITY_INDEX_ATTEMPT"
+              [10m]
+            )
+          ) > 5
+        labels:
+          alert_type: security_event
+          service: opensearch
+          severity: critical
+        annotations:
+          description: |
+            OpenSearch in {{ $labels.juju_model }} has {{ $value }} security events {{ $labels.audit_category }} in the last 10 minutes.
+            This may indicate authentication failures, unauthorized access attempts, or security misconfigurations.
+          summary: "Critical security audit events (>5) in OpenSearch"

--- a/rules/prod/loki/charmed_opensearch_rules.rule
+++ b/rules/prod/loki/charmed_opensearch_rules.rule
@@ -21,7 +21,7 @@ groups:
           severity: warning
         annotations:
           description: |
-            OpenSearch in {{ $labels.juju_model }} has {{ $value }} security events {{ $labels.audit_category }} in the last 10 minutes.
+            OpenSearch in {{ $labels.juju_model }} has {{ $value }} {{ $labels.audit_category }} security events in the last 10 minutes.
             This may indicate authentication failures, unauthorized access attempts, or security misconfigurations.
           summary: "High security audit events (>3) in OpenSearch"
 
@@ -44,6 +44,6 @@ groups:
           severity: critical
         annotations:
           description: |
-            OpenSearch in {{ $labels.juju_model }} has {{ $value }} security events {{ $labels.audit_category }} in the last 10 minutes.
+            OpenSearch in {{ $labels.juju_model }} has {{ $value }} {{ $labels.audit_category }} security events in the last 10 minutes.
             This may indicate authentication failures, unauthorized access attempts, or security misconfigurations.
           summary: "Critical security audit events (>5) in OpenSearch"


### PR DESCRIPTION
Add rules and setup guides for charmed Opensearch to fire alert when [security events](https://docs.opensearch.org/latest/security/audit-logs/index/#tracked-events) happens:
- Warning when a security event happens more than 3 times within last 10m
- Critical when a security event happens more than 5 times within last 10m

Example:
<img width="1564" height="980" alt="Screenshot from 2026-01-29 11-43-44" src="https://github.com/user-attachments/assets/c9f908fe-4d9e-40b6-8643-02df20251f55" />

---
**Note**: 
- Since Opensearch native logs do not contain HTTP response code for REST API calls, cannot monitor on criterion like "20% API failure within last hour"
- The rules in this PR assume `opentelemetry-collector` is used instead of `grafana-agent`, so they will not work with `grafana-agent`