### PR TITLE
Add Loki rules for charmed Kubeflow gateway API failures

### DIFF
--- a/rules/prod/loki/charmed_kubeflow_gateway_rules.rule
+++ b/rules/prod/loki/charmed_kubeflow_gateway_rules.rule
@@ -1,0 +1,51 @@
+namespace: kubeflow_gateway_rules
+groups:
+  - name: kubeflow-gateway-api-failures
+    rules:
+      - alert: KubeflowGatewayFailureRateHigh
+        expr: |-
+          (
+            sum by (juju_model) (
+              rate({charm="istio-gateway"}
+                |~ `" [45][0-9]{2} ` [1h])
+              )
+              /
+              sum by (juju_model) (
+              rate({charm="istio-gateway"}
+                  |~ `" [0-9]{3} ` [1h])
+              )
+          ) * 100 > 20
+        labels:
+          alert_type: api_failure_rate
+          service: kubeflow
+          severity: warning
+        annotations:
+          description: |
+            User-facing API failure rate for Kubeflow in {{ $labels.juju_model }}
+            is {{ $value | printf "%.0f" }}% over the last hour, exceeding the 20% threshold.
+            This indicates issues with user access to dashboards, notebooks, or pipelines.
+          summary: "Kubeflow gateway error rate >20% in {{ $labels.juju_model }}"
+
+      - alert: KubeflowGatewayFailureRateCritical
+        expr: |-
+          (
+            sum by (juju_model) (
+              rate({charm="istio-gateway"}
+                  |~ `" [45][0-9]{2} ` [1h])
+              )
+              /
+              sum by (juju_model) (
+              rate({charm="istio-gateway"}
+                  |~ `" [0-9]{3} ` [1h])
+              )
+          ) * 100 > 70
+        labels:
+          alert_type: api_failure_rate
+          service: kubeflow
+          severity: critical
+        annotations:
+          description: |
+            User-facing API failure rate for Kubeflow in {{ $labels.juju_model }}
+            is {{ $value | printf "%.0f" }}% over the last hour, exceeding the 70% threshold.
+            This indicates severe issues affecting user access to the Kubeflow platform.
+          summary: "Kubeflow gateway error rate >70% in {{ $labels.juju_model }}"


### PR DESCRIPTION
Add 2 Loki rules to alert on API failure detected from [istio-gateway](https://charmhub.io/istio-gateway) (which is the gateway API for a charmed KF deployment):

- Warning alert when API failure rate >20% within last 1 hour
- Critical alert when API failure rate >70% within last 1 hour

Example (test with 5% failure):
<img width="1581" height="803" alt="Screenshot from 2026-01-30 14-44-01" src="https://github.com/user-attachments/assets/44323226-a13d-440a-ad9d-899858b23507" />
